### PR TITLE
Build multilingual KinaBot wellness reflection

### DIFF
--- a/aoi_kinabot_app/.dockerignore
+++ b/aoi_kinabot_app/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.env
+data/
+*.sqlite3
+*.log
+assets/
+test_*.py
+*.md

--- a/aoi_kinabot_app/.env.example
+++ b/aoi_kinabot_app/.env.example
@@ -1,0 +1,20 @@
+# Optional anonymous score-change insight layer only.
+# Never send audio, transcripts, names, or email addresses.
+OPENAI_API_KEY=replace-me
+KINABOT_INSIGHT_MODEL=gpt-4.1-mini
+KINABOT_WHISPER_MODEL=small
+KINABOT_WHISPER_COMPUTE_TYPE=int8
+KINABOT_ENVIRONMENT=production
+KINABOT_ALLOW_LOCAL_CODES=false
+KINABOT_MAX_TESTS_PER_DAY=2
+KINABOT_MAX_AUDIO_MB=25
+KINABOT_ADMIN_KEY=replace-with-a-long-random-secret
+KINABOT_DATABASE_PATH=/data/kinabot.sqlite3
+
+# Email verification (Amazon SES SMTP in production)
+KINABOT_SMTP_HOST=email-smtp.us-west-2.amazonaws.com
+KINABOT_SMTP_PORT=587
+KINABOT_SMTP_FROM_EMAIL=verified-sender@example.com
+KINABOT_SMTP_USERNAME=replace-me
+KINABOT_SMTP_PASSWORD=replace-me
+KINABOT_SMTP_USE_TLS=true

--- a/aoi_kinabot_app/.streamlit/config.toml
+++ b/aoi_kinabot_app/.streamlit/config.toml
@@ -1,0 +1,6 @@
+[server]
+maxUploadSize = 25
+headless = true
+
+[browser]
+gatherUsageStats = false

--- a/aoi_kinabot_app/ARCHITECTURE.md
+++ b/aoi_kinabot_app/ARCHITECTURE.md
@@ -1,0 +1,138 @@
+# KinaBot Current Architecture
+
+This document applies only to the Aoi-maintained implementation in
+`aoi_kinabot_app/`. Repository-root applications are historical prototypes.
+
+## Data Flow
+
+```text
+User's phone or PC
+  └─ source recording remains on the user's device
+       │ user selects a file
+       ▼
+KinaBot application
+  ├─ temporary audio copy
+  ├─ private/local speech-to-text
+  ├─ language-specific Python/NLP feature extraction
+  ├─ deterministic, versioned feature scoring
+  ├─ delete temporary audio and full transcript
+  └─ store account, session metadata, raw metrics and scores
+       │
+       ├─ fewer than 3 sessions → show sample results only
+       └─ 3+ sessions → show descriptive personal trend
+                          │
+                          ▼
+Optional OpenAI insight layer
+  ├─ receives anonymous score history/deltas only
+  ├─ receives no audio, transcript, name or email
+  ├─ explains one evidence-informed daily wellness action
+  └─ returns no diagnosis, disease risk or cognitive-decline claim
+```
+
+## Responsibility Matrix
+
+| Responsibility | Owner |
+|---|---|
+| Speech-to-text | Private/local transcription engine |
+| Linguistic and acoustic feature extraction | KinaBot Python/NLP |
+| Feature-score calculation | KinaBot versioned scoring engine |
+| Personal baseline and trend calculation | KinaBot application |
+| Account and session storage | KinaBot database |
+| Plain-language daily action | Optional OpenAI insight layer |
+| Evidence and safety boundaries | Curated KinaBot research/action library |
+
+OpenAI is not a scoring model and is not the source of truth for user features.
+
+## Multilingual Design
+
+The initial interface supports English, Japanese, and Chinese. Each language
+adapter should own:
+
+- word or character segmentation;
+- sentence boundary detection;
+- language-specific discourse connectors;
+- repetition normalization;
+- emotional-expression vocabulary;
+- pace units and appropriate reference ranges; and
+- test fixtures written by fluent speakers.
+
+Every stored score includes a scoring-model version. Cross-language scores
+must not be treated as equivalent until adapters are tested and calibrated.
+
+## Longitudinal Insight Rules
+
+One recording produces a sample description, not a conclusion about a person.
+Trends unlock only after at least three sessions.
+
+The application may report:
+
+- higher, lower, or similar relative to the user's prior samples;
+- how many sessions were compared;
+- the comparison time window; and
+- whether an observed pattern repeated.
+
+It must not translate a lower feature value into a diagnosis, medical risk,
+intelligence estimate, cognitive age, or claim of cognitive decline.
+
+## Actionable Wellness Insight Contract
+
+The optional OpenAI layer receives only:
+
+- interface language;
+- anonymous feature identifiers;
+- rounded score history or deltas;
+- number and date range of sessions; and
+- allowed actions and citations from a curated research library.
+
+It returns:
+
+- one small action;
+- a start time such as “tomorrow”;
+- a realistic duration such as 10 or 20 minutes;
+- a suggested frequency;
+- a short, non-medical rationale;
+- the supporting research citation; and
+- a boundary statement.
+
+Example:
+
+> Tomorrow, talk with a friend or family member for 20 minutes. Tell one story
+> about your day and ask one follow-up question. Social engagement is a general
+> cognitive-wellness habit. This is not a medical assessment and does not mean
+> that a health problem exists.
+
+If OpenAI is unavailable, a curated deterministic action library is the safe
+fallback.
+
+## Stored and Ephemeral Data
+
+| Data | Retention |
+|---|---|
+| Source audio on user device | Controlled by user |
+| Temporary uploaded audio | Deleted after processing |
+| Full transcript | Processed in memory; not persisted |
+| Name and email | Stored for account access |
+| Consent/profile | Stored and versioned |
+| Session metadata | Stored |
+| Raw NLP feature metrics | Stored |
+| Feature scores and scoring version | Stored |
+| Optional habit check-ins | Stored |
+| OpenAI input/output | Data-minimized; logs redacted where supported |
+
+Production should encrypt data in transit and at rest, restrict administrative
+access, maintain backups and audit logs, and provide account/data deletion.
+
+## Production Direction
+
+```text
+Route 53 / stable domain
+  → Application Load Balancer (HTTPS)
+  → ECS Fargate KinaBot service
+  → RDS PostgreSQL
+  → Secrets Manager
+  → SES email verification
+  → CloudWatch logs, metrics and alarms
+```
+
+The deployment must use its own service, database, secrets, logs, and backups
+and must not overwrite an existing application.

--- a/aoi_kinabot_app/Dockerfile
+++ b/aoi_kinabot_app/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    KINABOT_ENVIRONMENT=production \
+    KINABOT_ALLOW_LOCAL_CODES=false \
+    KINABOT_DATABASE_PATH=/data/kinabot.sqlite3
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+RUN mkdir -p /data
+
+VOLUME ["/data"]
+EXPOSE 8501
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8501/_stcore/health', timeout=3)"
+
+CMD ["streamlit", "run", "app.py", \
+     "--server.address=0.0.0.0", \
+     "--server.port=8501", \
+     "--server.headless=true", \
+     "--browser.gatherUsageStats=false"]

--- a/aoi_kinabot_app/README.md
+++ b/aoi_kinabot_app/README.md
@@ -1,51 +1,147 @@
-# Aoi-Maintained KinaBot App
+# KinaBot — Aoi-Maintained Application
 
-This folder is reserved for the new Aoi-maintained KinaBot implementation.
+> **Current implementation and product direction maintained by Aoi Minamoto through AImoji LLC.**
 
-The goal of this implementation is to build a safer, dignity-first, consent-first, and privacy-aware web application for speech reflection and family support.
+This folder contains the current KinaBot application. Files elsewhere in this
+repository are retained as historical exploratory work and do not define this
+implementation's architecture, scoring policy, privacy policy, or product
+claims.
 
-Earlier prototype work remains in the repository for transparency, but future public-facing development should be organized here with clearer ownership, safety wording, privacy handling, and responsible-use boundaries.
+KinaBot is a multilingual speech and language reflection tool. Its core value
+is a versioned Python/NLP feature engine that calculates consistent features
+from each user's voice sample and helps that user observe personal patterns
+over time.
 
-## Development Priorities
+KinaBot is not a medical device. It does not diagnose a condition, calculate
+disease risk, estimate cognitive age, or replace professional care.
 
-- Use communication pattern summaries instead of diagnosis-like language
-- Avoid estimated cognitive age or medical risk claims
-- Add clear consent notice before recording
-- Explain whether audio is saved, deleted, or processed by external services
-- Minimize data retention
-- Keep reports respectful, non-alarming, and suitable for family discussion
+## Simple User Experience
 
-## App UI Image
-![KinaBot V1 local UI](assets/kinabot-v1-ui.png)
+1. Sign in with an email verification code.
+2. Choose English, Japanese, or Chinese.
+3. Select a recording stored on the user's phone or computer.
+4. Run one analysis and see that sample's feature scores.
+5. After three or more sessions, see personal trends and changes.
+6. Receive a small, practical daily wellness action when appropriate.
 
-## Local Audio Upload
+The pilot allows up to two analyses per user per day.
 
-The V1 local app accepts speech audio uploads for pilot-flow testing.
-Uploaded audio is temporarily written for processing and then deleted immediately.
-The local SQLite database stores session metadata and calculated feature scores, not raw audio or transcripts.
+## Core NLP Work
 
-Automatic speech-to-text is available when `OPENAI_API_KEY` is configured.
-If the key is missing, the local skeleton still accepts manual transcript text after upload.
+KinaBot itself calculates the feature scores. OpenAI does **not** calculate
+them.
 
-Optional environment variable:
+The versioned NLP pipeline measures observable properties such as:
 
-- `KINABOT_TRANSCRIPTION_MODEL` (`gpt-4o-transcribe` by default)
+- vocabulary or expression variety;
+- response development and amount of speech;
+- sentence structure and organization;
+- speaking pace;
+- pause behavior;
+- repetition patterns;
+- emotional expression in language; and
+- transcription clarity.
 
-## Local Email Verification
+These are feature levels for one sample. A higher or lower value is not, by
+itself, evidence of better or worse health. Trend insights compare a user with
+their own prior samples across multiple sessions and preserve the scoring
+version used for every result.
 
-The local app can send verification codes by email when SMTP settings are configured.
-If these settings are missing, the app shows the code on screen for local development.
+English, Japanese, and Chinese are the first supported languages. Future
+languages must use language-appropriate segmentation, grammar features,
+normalization, testing, and calibration rather than treating English rules as
+universal.
 
-Required environment variables:
+See [ARCHITECTURE.md](ARCHITECTURE.md) and
+[feature-score-design.md](feature-score-design.md).
 
-- `KINABOT_SMTP_HOST`
-- `KINABOT_SMTP_PORT`
-- `KINABOT_SMTP_FROM_EMAIL`
+## OpenAI's Limited Role
 
-Optional environment variables:
+OpenAI is an optional insight layer used only after KinaBot has calculated the
+scores. A future request may contain minimum anonymous structured data such as:
 
-- `KINABOT_SMTP_USERNAME`
-- `KINABOT_SMTP_PASSWORD`
-- `KINABOT_SMTP_USE_TLS` (`true` by default)
+```json
+{
+  "language": "Japanese",
+  "sessions_compared": 4,
+  "feature_changes": {
+    "expression_variety": [72, 68, 61],
+    "speech_pace": [64, 65, 64],
+    "repetition_consistency": [74, 65, 58]
+  }
+}
+```
 
-For AWS deployment, these values can be connected to Amazon SES SMTP credentials.
+The request must not contain raw audio, a full transcript, name, email, or
+direct identifiers. OpenAI must never be the feature-scoring authority.
+
+The resulting insight should be a practical action for ordinary daily life:
+
+- talk with a friend or family member for 20 minutes tomorrow;
+- take a safe walk and tell someone one story from the day;
+- read for 10 minutes and summarize the main idea;
+- contact a friend the user has not spoken with recently; or
+- choose an appropriate Mediterranean-style meal.
+
+Every action should say what to do, when, for how long, how often, why it may
+support general cognitive wellness, and which research source supports the
+general habit. It must not claim to treat a condition, repair a score, or prove
+that a score change represents cognitive decline.
+
+## Privacy and Data
+
+The source recording remains on the user's phone or computer. When selected
+for analysis, KinaBot creates only a temporary server-side working copy.
+
+- Speech-to-text is processed locally/private to the KinaBot environment.
+- Python/NLP feature calculation is performed by KinaBot.
+- Temporary audio is deleted after processing, including error paths.
+- Raw audio and full transcripts are not stored.
+- Audio and full transcripts are not sent to OpenAI.
+
+KinaBot stores the minimum data needed for accounts and longitudinal use:
+
+- name and email;
+- optional profile fields and consent version;
+- session date, language, duration, and software/scoring versions;
+- calculated raw feature metrics and feature scores; and
+- optional self-reported wellness habit check-ins.
+
+Public research or publication requires separate consent, governance,
+de-identification, and ethics review as applicable.
+
+## Evidence-Informed Wellness Actions
+
+Advice is general wellness information, not medical advice. Sources used to
+shape the action library include:
+
+- [WHO cognitive-decline and dementia risk-reduction guidelines](https://www.who.int/publications/i/item/9789241550543)
+- [Mediterranean diet trial — PubMed](https://pubmed.ncbi.nlm.nih.gov/23670794/)
+- [Social engagement and cognitive function study](https://pmc.ncbi.nlm.nih.gov/articles/PMC6778491/)
+
+A source supports the general habit; it does not establish that the habit will
+change an individual user's KinaBot score.
+
+## Run on a Local PC
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+streamlit run app.py
+```
+
+Open the local URL shown by Streamlit, normally `http://localhost:8501`.
+Local transcription uses `faster-whisper`. The first analysis may take longer
+while its model is downloaded and loaded; later analyses reuse the model.
+
+OpenAI is not required for transcription or NLP scoring. If the optional
+anonymous insight layer is later enabled, keep its API key in a local
+environment variable or AWS Secrets Manager—never in GitHub.
+
+## Deployment Direction
+
+The application is packaged for Docker and future 24/7 AWS hosting. Production
+should use HTTPS, a continuously running container service, managed relational
+storage, secrets management, email delivery, health checks, backups, and
+centralized logs. It must remain isolated from existing applications.

--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -9,34 +9,63 @@ import streamlit as st
 
 from audio_processing import SUPPORTED_AUDIO_TYPES, accept_audio_upload
 from auth import create_local_verification_code, verify_code
-from config import APP_VERSION, CONSENT_VERSION, MAX_TESTS_PER_DAY, SCORING_MODEL_VERSION
+from config import (
+    ADMIN_KEY,
+    ALLOW_LOCAL_VERIFICATION_CODES,
+    APP_VERSION,
+    CONSENT_VERSION,
+    MAX_AUDIO_BYTES,
+    MAX_TESTS_PER_DAY,
+    SCORING_MODEL_VERSION,
+)
 from database import (
     count_tests_today,
     create_test_session,
     get_admin_metrics,
+    get_user_habit_checkins,
     get_user_scores,
     init_db,
     list_admin_test_records,
     list_admin_users,
     record_consent,
     save_feature_scores,
+    save_habit_checkins,
     update_user_profile,
     upsert_user,
 )
 from email_delivery import send_verification_email
-from scoring import calculate_feature_scores
+from insight_service import generate_wellness_insight
+from language_analysis import LANGUAGE_CODES, analyze_transcript
 from speech_to_text import (
-    OPENAI_TRANSCRIPTION_TYPES,
+    LOCAL_TRANSCRIPTION_TYPES,
     speech_to_text_configured,
     transcribe_audio_upload,
 )
+from wellness_guidance import wellness_suggestions
 
 
-st.set_page_config(page_title="KinaBot V1", layout="wide")
+st.set_page_config(page_title="KinaBot", page_icon="🎙️", layout="centered")
 init_db()
 
-st.title("KinaBot V1")
-st.caption("Speech and language-based cognitive wellness reflection. Not a medical diagnosis.")
+st.markdown(
+    """
+    <style>
+    .block-container {max-width: 760px; padding-top: 2rem; padding-bottom: 4rem;}
+    h1 {letter-spacing: -0.04em;}
+    .privacy-card {
+        padding: 0.9rem 1rem; border-radius: 0.8rem;
+        background: rgba(46, 160, 67, 0.08);
+        border: 1px solid rgba(46, 160, 67, 0.20);
+        margin: 0.5rem 0 1rem;
+    }
+    .privacy-card strong {color: #238636;}
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+st.title("KinaBot")
+st.caption("A simple reflection on one voice sample · English · 日本語 · 中文")
 
 if "email" not in st.session_state:
     st.session_state.email = ""
@@ -46,14 +75,11 @@ if "user_id" not in st.session_state:
     st.session_state.user_id = None
 if "verified" not in st.session_state:
     st.session_state.verified = False
-if "transcript_text" not in st.session_state:
-    st.session_state.transcript_text = ""
-
-
-with st.sidebar:
-    st.header("Access")
+if not st.session_state.verified:
+    st.subheader("Sign in")
+    st.caption("We use your email to keep your private history together.")
     email = st.text_input("Email", value=st.session_state.email)
-    if st.button("Send verification code"):
+    if st.button("Send code", use_container_width=True):
         if not email.strip():
             st.warning("Enter an email address first.")
         else:
@@ -64,11 +90,13 @@ with st.sidebar:
                 st.success(message)
             else:
                 st.warning(message)
-                st.info(f"Local dev code: {code}")
-                st.caption("Set SMTP environment variables to send this code by email.")
+                if ALLOW_LOCAL_VERIFICATION_CODES:
+                    st.info(f"Local dev code: {code}")
+                else:
+                    st.error("Email delivery is unavailable. Please try again later.")
 
-    code = st.text_input("Verification code")
-    if st.button("Verify code"):
+    code = st.text_input("6-digit code")
+    if st.button("Continue", type="primary", use_container_width=True):
         email_hash = verify_code(email, code)
         if not email_hash:
             st.error("Invalid or expired code.")
@@ -77,66 +105,52 @@ with st.sidebar:
             st.session_state.email_hash = email_hash
             st.session_state.user_id = upsert_user(email_hash, email=st.session_state.email)
             st.session_state.verified = True
-            st.success("Verified.")
+            st.rerun()
 
-    st.divider()
-    st.caption(f"App: {APP_VERSION}")
-    st.caption(f"Consent: {CONSENT_VERSION}")
-    st.caption(f"Scoring: {SCORING_MODEL_VERSION}")
-
-    st.divider()
-    with st.expander("Local admin metrics"):
-        admin_key = st.text_input("Admin key", type="password")
-        if admin_key == "local-admin":
-            metrics = get_admin_metrics()
-            st.metric("Users", metrics["total_users"])
-            st.metric("Tests", metrics["total_tests"])
-            st.metric("Scores", metrics["total_scores"])
-            st.metric("Active today", metrics["active_users_today"])
-        elif admin_key:
-            st.warning("Invalid local admin key.")
-
-
-if not st.session_state.verified:
-    st.info("Enter your email and local verification code to start.")
+    st.caption("KinaBot is a wellness reflection tool, not a medical device.")
     st.stop()
 
 
-st.subheader("Pilot Profile")
-st.caption("These fields are optional and help KinaBot understand pilot usage. Do not enter medical history.")
-profile_col1, profile_col2, profile_col3 = st.columns(3)
-with profile_col1:
+with st.expander("Account"):
+    st.caption(st.session_state.email)
+    display_name = st.text_input("Name", placeholder="Your name")
     age_range = st.selectbox(
         "Age range (optional)",
         ["Prefer not to say", "Under 30", "30-44", "45-59", "60-74", "75+"],
     )
-with profile_col2:
     primary_language = st.selectbox(
         "Primary language (optional)",
         ["Prefer not to say", "English", "Japanese", "Chinese", "Spanish", "Other"],
     )
-with profile_col3:
     country_region = st.text_input("Country / region (optional)", placeholder="Example: US")
+    if st.button("Save account"):
+        update_user_profile(
+            st.session_state.user_id,
+            display_name.strip() or None,
+            None if age_range == "Prefer not to say" else age_range,
+            None if primary_language == "Prefer not to say" else primary_language,
+            country_region.strip() or None,
+        )
+        st.success("Account saved.")
 
-if st.button("Save pilot profile"):
-    update_user_profile(
-        st.session_state.user_id,
-        None if age_range == "Prefer not to say" else age_range,
-        None if primary_language == "Prefer not to say" else primary_language,
-        country_region.strip() or None,
-    )
-    st.success("Pilot profile saved.")
+st.markdown(
+    """
+    <div class="privacy-card">
+      <strong>Your recording is not saved.</strong><br>
+      Your selected file is processed privately on the KinaBot server with local Python,
+      then the temporary copy is deleted. It is not sent to OpenAI. KinaBot stores your account, scores, usage
+      history, and optional habit check-ins—not the raw audio or full transcript.
+    </div>
+    """,
+    unsafe_allow_html=True,
+)
 
-
-st.subheader("Consent")
 consent = st.checkbox(
-    "I understand KinaBot is for personal reflection, not medical diagnosis. "
-    "For the V1 pilot, KinaBot may store my email, optional profile fields, usage records, "
-    "and calculated feature scores. Raw audio and transcripts should not be stored by default."
+    "I understand and agree. KinaBot describes this sample only; it does not assess health."
 )
 
 if not consent:
-    st.warning("Please accept the consent notice before starting a test.")
+    st.caption("Please agree before analyzing a recording.")
     st.stop()
 
 record_consent(st.session_state.user_id, CONSENT_VERSION)
@@ -144,65 +158,27 @@ record_consent(st.session_state.user_id, CONSENT_VERSION)
 today = date.today().isoformat()
 tests_today = count_tests_today(st.session_state.user_id, today)
 remaining = MAX_TESTS_PER_DAY - tests_today
-st.metric("Tests remaining today", max(0, remaining))
-
 if remaining <= 0:
-    st.warning("You have reached today's V1 pilot limit.")
+    st.info("You have completed today's two reflections. Come back tomorrow.")
     st.stop()
 
-st.subheader("V1 Speech Upload Test")
+st.subheader("New reflection")
 
 language = st.radio(
-    "Language",
-    [
-        "English",
-        "Japanese (planned)",
-        "Chinese (planned)",
-        "Spanish (planned)",
-    ],
+    "1 · Choose the language spoken",
+    ["English", "日本語", "中文"],
     horizontal=True,
-    help="English scoring is active in V1. Japanese, Chinese, and Spanish are planned before the end of 2026.",
+    help="Choose the language actually spoken in the uploaded recording.",
 )
 
-st.markdown(
-    """
-    <div style="display:flex; gap:10px; flex-wrap:wrap; margin: 0.5rem 0 1rem 0;">
-      <span style="background:#e8f5e9; color:#1b5e20; border:1px solid #a5d6a7; border-radius:6px; padding:6px 10px; font-size:0.9rem;">English: active</span>
-      <span style="background:#f3f4f6; color:#6b7280; border:1px solid #d1d5db; border-radius:6px; padding:6px 10px; font-size:0.9rem;">Japanese: planned by end of 2026</span>
-      <span style="background:#f3f4f6; color:#6b7280; border:1px solid #d1d5db; border-radius:6px; padding:6px 10px; font-size:0.9rem;">Chinese: planned by end of 2026</span>
-      <span style="background:#f3f4f6; color:#6b7280; border:1px solid #d1d5db; border-radius:6px; padding:6px 10px; font-size:0.9rem;">Spanish: planned by end of 2026</span>
-    </div>
-    """,
-    unsafe_allow_html=True,
-)
-
-if language != "English":
-    st.info(
-        f"{language.replace(' (planned)', '')} support is planned before the end of 2026. "
-        "For now, please use English to test the V1 scoring skeleton."
-    )
-    st.stop()
-
-session_type = st.radio(
-    "Session type",
-    ["Daily full reflection", "Quick check-in"],
-    horizontal=True,
-    help="Daily full reflection is intended for 2-3 minutes. Quick check-in is intended for about 60 seconds.",
-)
-default_duration = 180.0 if session_type == "Daily full reflection" else 60.0
-
-st.caption(
-    "Upload a speech audio file for the V1 pilot flow. The local skeleton accepts the file, "
-    "temporarily processes it, and deletes the temporary copy."
-)
+session_type = "Daily reflection"
 
 uploaded_audio = st.file_uploader(
-    "Upload speech audio",
+    "2 · Choose a recording from your phone or computer",
     type=SUPPORTED_AUDIO_TYPES,
     help="Supported local test formats: WAV, MP3, M4A, AAC, OGG, FLAC.",
 )
 
-audio_metadata = None
 if uploaded_audio is not None:
     st.audio(uploaded_audio)
     st.caption(
@@ -210,103 +186,157 @@ if uploaded_audio is not None:
         f"({uploaded_audio.size / 1024:.1f} KB). Raw audio will not be stored by this app."
     )
     audio_extension = uploaded_audio.name.rsplit(".", 1)[-1].lower()
-    can_transcribe = audio_extension in OPENAI_TRANSCRIPTION_TYPES
+    can_transcribe = audio_extension in LOCAL_TRANSCRIPTION_TYPES
     if not can_transcribe:
         st.info(
             "This file can be uploaded for local flow testing, but automatic transcription supports "
             "MP3, MP4, MPEG, MPGA, M4A, WAV, and WEBM."
         )
-    elif not speech_to_text_configured():
-        st.info(
-            "Automatic speech-to-text is not enabled in this local environment. "
-            "Set OPENAI_API_KEY for pilot-style testing."
-        )
-    elif st.button("Transcribe uploaded audio"):
-        with st.spinner("Transcribing audio without storing the raw file..."):
-            transcribed, transcript_or_error = transcribe_audio_upload(uploaded_audio, uploaded_audio.name)
-        if transcribed:
-            st.session_state.transcript_text = transcript_or_error
-            st.success("Transcript generated. Review it before calculating scores.")
-        else:
-            st.warning(transcript_or_error)
-
-sample_text = st.text_area(
-    "Transcript generated from uploaded speech",
-    value=st.session_state.transcript_text,
-    height=160,
-    placeholder="Example: Today I went to the store and talked with my family...",
-    help="When speech-to-text is configured, this is filled automatically. In local dev without an API key, enter test text here.",
-)
-duration_seconds = st.number_input(
-    "Optional speaking duration in seconds",
-    min_value=0.0,
-    value=default_duration,
-    step=1.0,
-)
-
-if st.button("Calculate feature scores"):
+st.caption(f"{max(0, remaining)} of {MAX_TESTS_PER_DAY} reflections available today")
+if st.button("3 · Analyze", type="primary", use_container_width=True):
     if uploaded_audio is None:
         st.warning("Upload a speech audio file first.")
-    elif not sample_text.strip():
-        st.warning("Enter transcript text first.")
+    elif uploaded_audio.size > MAX_AUDIO_BYTES:
+        st.warning(f"Audio must be {MAX_AUDIO_BYTES // (1024 * 1024)} MB or smaller.")
+    elif uploaded_audio.name.rsplit(".", 1)[-1].lower() not in LOCAL_TRANSCRIPTION_TYPES:
+        st.warning("Use MP3, MP4, MPEG, MPGA, M4A, WAV, or WEBM for automatic analysis.")
     else:
-        audio_metadata = accept_audio_upload(uploaded_audio, uploaded_audio.name)
-        scores = calculate_feature_scores(sample_text, duration_seconds)
-        session_number = tests_today + 1
-        test_session_id = create_test_session(
-            user_id=st.session_state.user_id,
-            session_date=today,
-            session_number=session_number,
-            app_version=APP_VERSION,
-            consent_version=CONSENT_VERSION,
-            scoring_model_version=SCORING_MODEL_VERSION,
-            session_type=session_type,
-            language="English",
-            duration_seconds=duration_seconds,
-        )
-        save_feature_scores(test_session_id, scores)
+        with st.status("Processing your recording…", expanded=True) as analysis_status:
+            st.write("Transcribing privately on the KinaBot server…")
+            transcribed, transcript_or_error, detected_duration = transcribe_audio_upload(
+                uploaded_audio,
+                uploaded_audio.name,
+                LANGUAGE_CODES[language],
+            )
+            if not transcribed:
+                analysis_status.update(label="Transcription failed", state="error")
+                st.error(transcript_or_error)
+                st.stop()
 
-        st.success(
-            f"Session {session_number} saved. Audio upload accepted and temporary audio deleted. "
-            "No raw audio or transcript stored by this skeleton."
-        )
-        st.json(
-            {
-                "audio_filename": audio_metadata["filename"],
-                "audio_size_bytes": audio_metadata["bytes"],
-                "detected_wav_duration_seconds": audio_metadata["duration_seconds"],
-                "temporary_audio_deleted": True,
-            }
-        )
-        df = pd.DataFrame(scores)[["feature_name", "score", "raw_metric", "explanation"]]
-        st.dataframe(df, width="stretch", hide_index=True)
+            st.write("Analyzing observable communication patterns…")
+            scores, session_summary = analyze_transcript(
+                transcript_or_error,
+                language,
+                detected_duration,
+            )
+            audio_metadata = accept_audio_upload(uploaded_audio, uploaded_audio.name)
+            session_number = tests_today + 1
+            test_session_id = create_test_session(
+                user_id=st.session_state.user_id,
+                session_date=today,
+                session_number=session_number,
+                app_version=APP_VERSION,
+                consent_version=CONSENT_VERSION,
+                scoring_model_version=SCORING_MODEL_VERSION,
+                session_type=session_type,
+                language=language,
+                duration_seconds=detected_duration or audio_metadata["duration_seconds"],
+            )
+            save_feature_scores(test_session_id, scores)
+            analysis_status.update(label="Analysis complete", state="complete", expanded=False)
 
+        st.success(f"Session {session_number} saved. Raw audio and full transcript were not retained.")
+        st.info(session_summary)
+        score_df = pd.DataFrame(scores)[["feature_name", "score", "explanation"]]
+        st.dataframe(
+            score_df,
+            width="stretch",
+            hide_index=True,
+            column_config={
+                "score": st.column_config.ProgressColumn("Score", min_value=0, max_value=100)
+            },
+        )
+        st.caption(
+            "Scores describe observable features in this sample only. "
+            "They do not indicate health, ability, improvement, decline, or risk."
+        )
 
-st.subheader("Trend History")
+st.subheader("Your history")
 rows = get_user_scores(st.session_state.user_id)
 if not rows:
     st.caption("No saved scores yet.")
 else:
     history = pd.DataFrame([dict(row) for row in rows])
-    st.dataframe(history, width="stretch", hide_index=True)
-    chart_df = history.pivot_table(
-        index="created_at",
-        columns="feature_name",
-        values="score",
-        aggfunc="mean",
+    session_count = len(history[["created_at", "session_number"]].drop_duplicates())
+    if session_count < 3:
+        st.info(f"{session_count} of 3 sessions completed. Trends unlock after session 3.")
+    else:
+        chart_df = history.pivot_table(
+            index="created_at",
+            columns="feature_name",
+            values="score",
+            aggfunc="mean",
+        )
+        st.line_chart(chart_df)
+
+        ordered = history.sort_values("created_at")
+        first_scores = ordered.groupby("feature_name").first()["score"]
+        latest_scores = ordered.groupby("feature_name").last()["score"]
+        change = (latest_scores - first_scores).rename("observed_change").reset_index()
+        change["pattern"] = change["observed_change"].apply(
+            lambda value: "Higher in latest sample"
+            if value > 2
+            else ("Lower in latest sample" if value < -2 else "Similar")
+        )
+        st.markdown("#### Observed change since the first sample")
+        st.dataframe(change, width="stretch", hide_index=True)
+        st.caption(
+            "These are descriptive sample-to-sample differences only. "
+            "KinaBot does not infer health, improvement, decline, cause, or risk."
+        )
+        insight = generate_wellness_insight(
+            [dict(row) for row in rows],
+            language,
+        )
+        st.markdown("#### One small action")
+        if insight.get("encouragement"):
+            st.write(insight["encouragement"])
+        st.info(insight["action"])
+        st.caption(f"{insight['why']} [Research source]({insight['source']})")
+        st.caption(insight["boundary"])
+
+st.subheader("Optional wellness habits")
+habit_copy = wellness_suggestions(language, [])
+st.caption(
+    "Optional habit tracking is separate from speech scores. KinaBot does not claim "
+    "that a habit caused any score or sample change."
+)
+habit_values = {
+    habit_name: st.checkbox(label, key=f"habit_{today}_{habit_name}")
+    for habit_name, label in habit_copy["habit_labels"].items()
+}
+if st.button("Save today's habit check-in"):
+    save_habit_checkins(st.session_state.user_id, today, habit_values)
+    st.success("Today's optional wellness habits were saved.")
+
+habit_rows = get_user_habit_checkins(st.session_state.user_id)
+if habit_rows:
+    habit_history = pd.DataFrame([dict(row) for row in habit_rows])
+    habit_daily = (
+        habit_history.groupby("checkin_date", as_index=False)["completed"]
+        .sum()
+        .rename(columns={"completed": "habits_completed"})
     )
-    st.line_chart(chart_df)
+    st.bar_chart(habit_daily.set_index("checkin_date"))
+    st.caption("This chart shows self-reported habit completion only.")
 
 
-st.subheader("Local Admin Records")
-st.caption("Local development view. Production needs real admin authentication.")
-admin_view_key = st.text_input("Admin records key", type="password")
-if admin_view_key == "local-admin":
-    users_df = pd.DataFrame([dict(row) for row in list_admin_users()])
-    tests_df = pd.DataFrame([dict(row) for row in list_admin_test_records()])
-    st.markdown("#### Users")
-    st.dataframe(users_df, width="stretch", hide_index=True)
-    st.markdown("#### Test score records")
-    st.dataframe(tests_df, width="stretch", hide_index=True)
-elif admin_view_key:
-    st.warning("Invalid local admin key.")
+if ADMIN_KEY:
+    with st.sidebar.expander("Admin"):
+        admin_view_key = st.text_input("Admin key", type="password")
+        if admin_view_key == ADMIN_KEY:
+            metrics = get_admin_metrics()
+            st.metric("Users", metrics["total_users"])
+            st.metric("Tests", metrics["total_tests"])
+            users_df = pd.DataFrame([dict(row) for row in list_admin_users()])
+            tests_df = pd.DataFrame([dict(row) for row in list_admin_test_records()])
+            st.dataframe(users_df, hide_index=True)
+            st.dataframe(tests_df, hide_index=True)
+        elif admin_view_key:
+            st.warning("Invalid admin key.")
+
+st.divider()
+st.caption(
+    "KinaBot is for personal wellness reflection, not diagnosis or medical advice. "
+    f"{APP_VERSION}"
+)

--- a/aoi_kinabot_app/audio_processing.py
+++ b/aoi_kinabot_app/audio_processing.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import BinaryIO
 
 
-SUPPORTED_AUDIO_TYPES = ["wav", "mp3", "m4a", "aac", "ogg", "flac"]
+SUPPORTED_AUDIO_TYPES = ["wav", "mp3", "mp4", "mpeg", "mpga", "m4a", "webm"]
 
 
 def _wav_duration_seconds(path: Path) -> float | None:

--- a/aoi_kinabot_app/config.py
+++ b/aoi_kinabot_app/config.py
@@ -3,16 +3,25 @@
 import os
 from pathlib import Path
 
-APP_VERSION = "v1-local-skeleton"
-CONSENT_VERSION = "consent-v1"
-SCORING_MODEL_VERSION = "score-v1"
-OPENAI_TRANSCRIPTION_MODEL = os.getenv("KINABOT_TRANSCRIPTION_MODEL", "gpt-4o-transcribe")
+APP_VERSION = "v1.1-multilingual-pilot"
+CONSENT_VERSION = "consent-v1.1"
+SCORING_MODEL_VERSION = "score-v2-multilingual"
+OPENAI_INSIGHT_MODEL = os.getenv("KINABOT_INSIGHT_MODEL", "gpt-4.1-mini")
+ENVIRONMENT = os.getenv("KINABOT_ENVIRONMENT", "development").strip().lower()
+ALLOW_LOCAL_VERIFICATION_CODES = (
+    os.getenv("KINABOT_ALLOW_LOCAL_CODES", "true").strip().lower() == "true"
+    and ENVIRONMENT != "production"
+)
+ADMIN_KEY = os.getenv("KINABOT_ADMIN_KEY", "").strip()
 
 APP_DIR = Path(__file__).resolve().parent
 DATA_DIR = APP_DIR / "data"
-DATABASE_PATH = DATA_DIR / "kinabot_v1.sqlite3"
+DATABASE_PATH = Path(
+    os.getenv("KINABOT_DATABASE_PATH", str(DATA_DIR / "kinabot_v1.sqlite3"))
+)
 
-MAX_TESTS_PER_DAY = 2
+MAX_TESTS_PER_DAY = int(os.getenv("KINABOT_MAX_TESTS_PER_DAY", "2"))
+MAX_AUDIO_BYTES = int(os.getenv("KINABOT_MAX_AUDIO_MB", "25")) * 1024 * 1024
 VERIFICATION_CODE_TTL_MINUTES = 10
 
 SMTP_HOST = os.getenv("KINABOT_SMTP_HOST", "").strip()

--- a/aoi_kinabot_app/database.py
+++ b/aoi_kinabot_app/database.py
@@ -14,7 +14,8 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
-def get_connection(db_path: Path = DATABASE_PATH) -> sqlite3.Connection:
+def get_connection(db_path: Path | None = None) -> sqlite3.Connection:
+    db_path = db_path or DATABASE_PATH
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
@@ -35,6 +36,7 @@ def init_db() -> None:
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 email_hash TEXT NOT NULL UNIQUE,
                 email TEXT,
+                display_name TEXT,
                 age_range TEXT,
                 primary_language TEXT,
                 country_region TEXT,
@@ -84,9 +86,22 @@ def init_db() -> None:
                 created_at TEXT NOT NULL,
                 FOREIGN KEY (test_session_id) REFERENCES test_sessions(id)
             );
+
+            CREATE TABLE IF NOT EXISTS habit_checkins (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                checkin_date TEXT NOT NULL,
+                habit_name TEXT NOT NULL,
+                completed INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                UNIQUE(user_id, checkin_date, habit_name),
+                FOREIGN KEY (user_id) REFERENCES users(id)
+            );
             """
         )
         ensure_column(conn, "users", "email", "TEXT")
+        ensure_column(conn, "users", "display_name", "TEXT")
         ensure_column(conn, "users", "age_range", "TEXT")
         ensure_column(conn, "users", "primary_language", "TEXT")
         ensure_column(conn, "users", "country_region", "TEXT")
@@ -118,6 +133,7 @@ def upsert_user(email_hash: str, email: str | None = None) -> int:
 
 def update_user_profile(
     user_id: int,
+    display_name: str | None,
     age_range: str | None,
     primary_language: str | None,
     country_region: str | None,
@@ -126,10 +142,18 @@ def update_user_profile(
         conn.execute(
             """
             UPDATE users
-            SET age_range = ?, primary_language = ?, country_region = ?, last_active_at = ?
+            SET display_name = ?, age_range = ?, primary_language = ?,
+                country_region = ?, last_active_at = ?
             WHERE id = ?
             """,
-            (age_range, primary_language, country_region, utc_now_iso(), user_id),
+            (
+                display_name,
+                age_range,
+                primary_language,
+                country_region,
+                utc_now_iso(),
+                user_id,
+            ),
         )
 
 
@@ -138,9 +162,14 @@ def record_consent(user_id: int, consent_version: str) -> None:
         conn.execute(
             """
             INSERT INTO consent_events (user_id, consent_version, accepted_at)
-            VALUES (?, ?, ?)
+            SELECT ?, ?, ?
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM consent_events
+                WHERE user_id = ? AND consent_version = ?
+            )
             """,
-            (user_id, consent_version, utc_now_iso()),
+            (user_id, consent_version, utc_now_iso(), user_id, consent_version),
         )
 
 
@@ -272,6 +301,37 @@ def get_user_scores(user_id: int) -> list[sqlite3.Row]:
         ).fetchall()
 
 
+def save_habit_checkins(user_id: int, checkin_date: str, habits: dict[str, bool]) -> None:
+    now = utc_now_iso()
+    with get_connection() as conn:
+        conn.executemany(
+            """
+            INSERT INTO habit_checkins
+                (user_id, checkin_date, habit_name, completed, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(user_id, checkin_date, habit_name)
+            DO UPDATE SET completed = excluded.completed, updated_at = excluded.updated_at
+            """,
+            [
+                (user_id, checkin_date, name, int(completed), now, now)
+                for name, completed in habits.items()
+            ],
+        )
+
+
+def get_user_habit_checkins(user_id: int) -> list[sqlite3.Row]:
+    with get_connection() as conn:
+        return conn.execute(
+            """
+            SELECT checkin_date, habit_name, completed, updated_at
+            FROM habit_checkins
+            WHERE user_id = ?
+            ORDER BY checkin_date ASC, habit_name ASC
+            """,
+            (user_id,),
+        ).fetchall()
+
+
 def get_admin_metrics() -> dict:
     with get_connection() as conn:
         total_users = conn.execute("SELECT COUNT(*) AS count FROM users").fetchone()["count"]
@@ -293,7 +353,8 @@ def list_admin_users() -> list[sqlite3.Row]:
     with get_connection() as conn:
         return conn.execute(
             """
-            SELECT id, email, age_range, primary_language, country_region, created_at, last_active_at
+            SELECT id, email, display_name, age_range, primary_language,
+                   country_region, created_at, last_active_at
             FROM users
             ORDER BY created_at DESC
             """
@@ -306,6 +367,7 @@ def list_admin_test_records() -> list[sqlite3.Row]:
             """
             SELECT
                 u.email,
+                u.display_name,
                 u.age_range,
                 u.primary_language,
                 u.country_region,

--- a/aoi_kinabot_app/insight_service.py
+++ b/aoi_kinabot_app/insight_service.py
@@ -1,0 +1,147 @@
+"""Data-minimized, evidence-bounded wellness insight generation."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from config import OPENAI_INSIGHT_MODEL
+from wellness_guidance import (
+    MEDITERRANEAN_TRIAL,
+    SOCIAL_ENGAGEMENT_STUDY,
+    WHO_GUIDELINE,
+)
+
+
+ACTIONS = {
+    "English": [
+        {
+            "action": (
+                "Tomorrow, talk with a friend or family member for 20 minutes. "
+                "Tell one story about your day and ask one follow-up question."
+            ),
+            "why": "Social connection is a general cognitive-wellness habit.",
+            "source": SOCIAL_ENGAGEMENT_STUDY,
+        },
+        {
+            "action": (
+                "Tomorrow, if it is safe for you, take a comfortable 20-minute "
+                "walk and describe three things you noticed afterward."
+            ),
+            "why": "Regular physical activity is supported as a general wellness habit.",
+            "source": WHO_GUIDELINE,
+        },
+        {
+            "action": (
+                "At one meal tomorrow, include vegetables, legumes, whole grains, "
+                "fish, nuts, or olive oil in a way that fits your dietary needs."
+            ),
+            "why": "Mediterranean-style eating patterns have been studied for cognitive wellness.",
+            "source": MEDITERRANEAN_TRIAL,
+        },
+    ],
+    "日本語": [
+        {
+            "action": "明日、家族や友人と20分話しましょう。今日の出来事を一つ話し、相手にも質問を一つしてみてください。",
+            "why": "人との交流は、一般的な認知ウェルネス習慣の一つです。",
+            "source": SOCIAL_ENGAGEMENT_STUDY,
+        },
+        {
+            "action": "安全に行える場合、明日20分ほど無理のない散歩をし、後で気づいたことを三つ話してみましょう。",
+            "why": "定期的な身体活動は、一般的な健康習慣として支持されています。",
+            "source": WHO_GUIDELINE,
+        },
+        {
+            "action": "明日の一食に、体調や食事制限に合わせて、野菜、豆類、全粒穀物、魚、ナッツ、オリーブ油などを取り入れてみましょう。",
+            "why": "地中海食に近い食習慣は、認知ウェルネスとの関連が研究されています。",
+            "source": MEDITERRANEAN_TRIAL,
+        },
+    ],
+    "中文": [
+        {
+            "action": "从明天开始，和家人或朋友聊20分钟。讲一件今天发生的事，再问对方一个问题。",
+            "why": "保持社交联系是一种通用的认知健康生活习惯。",
+            "source": SOCIAL_ENGAGEMENT_STUDY,
+        },
+        {
+            "action": "如果身体情况允许，明天舒适地散步20分钟，之后说出途中注意到的三件事。",
+            "why": "规律的身体活动是一种有研究支持的通用健康习惯。",
+            "source": WHO_GUIDELINE,
+        },
+        {
+            "action": "明天选一餐，在符合自身饮食需要的前提下加入蔬菜、豆类、全谷物、鱼、坚果或橄榄油。",
+            "why": "偏地中海式的饮食模式已被用于认知健康相关研究。",
+            "source": MEDITERRANEAN_TRIAL,
+        },
+    ],
+}
+
+BOUNDARY = {
+    "English": "This is a general wellness action, not a medical assessment or treatment.",
+    "日本語": "これは一般的なウェルネス行動であり、医療評価や治療ではありません。",
+    "中文": "这是一项通用健康行动，不是医疗评估或治疗。",
+}
+
+
+def anonymous_trend_payload(history: list[dict[str, Any]], language: str) -> dict:
+    """Build the complete and exclusive payload allowed to leave KinaBot."""
+    feature_series: dict[str, list[float]] = {}
+    for row in history:
+        name = str(row["feature_name"])
+        feature_series.setdefault(name, []).append(round(float(row["score"]), 1))
+    return {
+        "language": language,
+        "sessions_compared": len(
+            {(str(row.get("created_at", "")), int(row.get("session_number", 0))) for row in history}
+        ),
+        "feature_scores": feature_series,
+    }
+
+
+def _fallback_action(language: str, payload: dict) -> dict:
+    series = payload.get("feature_scores", {})
+    largest_drop = min(
+        ((values[-1] - values[0], name) for name, values in series.items() if len(values) >= 2),
+        default=(0, ""),
+    )[1]
+    index = sum(ord(character) for character in largest_drop) % len(ACTIONS["English"])
+    result = dict(ACTIONS.get(language, ACTIONS["English"])[index])
+    result["boundary"] = BOUNDARY.get(language, BOUNDARY["English"])
+    result["generated_by"] = "KinaBot research action library"
+    return result
+
+
+def generate_wellness_insight(history: list[dict[str, Any]], language: str) -> dict:
+    """Generate one action; OpenAI sees anonymous score series and allowed actions only."""
+    payload = anonymous_trend_payload(history, language)
+    if payload["sessions_compared"] < 3 or not os.getenv("OPENAI_API_KEY", "").strip():
+        return _fallback_action(language, payload)
+
+    from openai import OpenAI
+
+    allowed = ACTIONS.get(language, ACTIONS["English"])
+    prompt = {
+        "task": (
+            "Choose exactly one allowed action and return its zero-based action_index. "
+            "Write one short encouraging sentence in the requested language. Do not "
+            "diagnose, infer cognitive decline, claim causation, or add medical advice."
+        ),
+        "anonymous_kina_scores": payload,
+        "allowed_actions": allowed,
+        "response_schema": {"action_index": 0, "encouragement": "short sentence"},
+    }
+    try:
+        response = OpenAI().responses.create(
+            model=OPENAI_INSIGHT_MODEL,
+            input=json.dumps(prompt, ensure_ascii=False),
+        )
+        parsed = json.loads(response.output_text)
+        index = max(0, min(len(allowed) - 1, int(parsed.get("action_index", 0))))
+        result = dict(allowed[index])
+        result["encouragement"] = str(parsed.get("encouragement", "")).strip()[:300]
+        result["boundary"] = BOUNDARY.get(language, BOUNDARY["English"])
+        result["generated_by"] = "OpenAI from anonymous scores and curated actions"
+        return result
+    except Exception:
+        return _fallback_action(language, payload)

--- a/aoi_kinabot_app/language_analysis.py
+++ b/aoi_kinabot_app/language_analysis.py
@@ -1,0 +1,27 @@
+"""Local, language-aware analysis for KinaBot speech samples."""
+
+from __future__ import annotations
+
+from scoring import calculate_feature_scores
+
+
+LANGUAGE_CODES = {
+    "English": "en",
+    "日本語": "ja",
+    "中文": "zh",
+}
+
+
+def analyze_transcript(
+    transcript: str,
+    language: str,
+    duration_seconds: float | None,
+) -> tuple[list[dict], str]:
+    """Calculate sample features locally; transcript text never leaves the server."""
+    scores = calculate_feature_scores(transcript, duration_seconds, language)
+    summaries = {
+        "English": "This summary describes observable patterns in this recording only.",
+        "日本語": "この結果は、今回の録音で観察された特徴だけを表します。",
+        "中文": "本结果仅描述这一次录音中可观察到的表达特点。",
+    }
+    return scores, summaries.get(language, summaries["English"])

--- a/aoi_kinabot_app/requirements.txt
+++ b/aoi_kinabot_app/requirements.txt
@@ -1,3 +1,6 @@
 streamlit>=1.32.0
 pandas>=2.0.0
 openai>=1.0.0
+faster-whisper>=1.1.0
+jieba>=0.42.1
+janome>=0.5.0

--- a/aoi_kinabot_app/scoring.py
+++ b/aoi_kinabot_app/scoring.py
@@ -23,12 +23,71 @@ FEATURE_EXPLANATIONS = {
     "Transcription Clarity": "This reflects whether the recording was clear enough for analysis.",
 }
 
+LANGUAGE_ALIASES = {
+    "English": "en",
+    "日本語": "ja",
+    "Japanese": "ja",
+    "中文": "zh",
+    "Chinese": "zh",
+}
+
+CONNECTORS = {
+    "en": {"and", "but", "because", "when", "while", "although", "if", "so"},
+    "ja": {"そして", "しかし", "だから", "ので", "から", "けれど", "もし", "また"},
+    "zh": {"而且", "但是", "因为", "所以", "如果", "然后", "虽然", "不过"},
+}
+
+EMOTION_WORDS = {
+    "en": {
+        "positive": {"good", "happy", "calm", "love", "great", "fine", "hope", "well"},
+        "negative": {"bad", "sad", "angry", "tired", "worry", "worried", "fear", "pain"},
+    },
+    "ja": {
+        "positive": {"良い", "嬉しい", "楽しい", "穏やか", "安心", "好き", "希望", "元気"},
+        "negative": {"悪い", "悲しい", "怒り", "疲れた", "心配", "不安", "怖い", "痛い"},
+    },
+    "zh": {
+        "positive": {"好", "开心", "高兴", "平静", "安心", "喜欢", "希望", "舒服"},
+        "negative": {"不好", "难过", "生气", "疲惫", "担心", "焦虑", "害怕", "疼痛"},
+    },
+}
+
+
+def language_code(language: str) -> str:
+    return LANGUAGE_ALIASES.get(language, "en")
+
 
 def clamp_score(value: float) -> float:
     return round(max(0.0, min(100.0, value)), 1)
 
 
-def tokenize(text: str) -> list[str]:
+def tokenize(text: str, language: str = "English") -> list[str]:
+    code = language_code(language)
+    if code == "ja":
+        try:
+            from janome.tokenizer import Tokenizer
+
+            return [
+                token.surface.lower()
+                for token in Tokenizer().tokenize(text)
+                if token.part_of_speech.split(",")[0] not in {"記号", "助詞", "助動詞"}
+            ]
+        except ImportError:
+            return re.findall(
+                r"[\u3400-\u9fff]+|[\u3040-\u309f]+|[\u30a0-\u30ff]+|[A-Za-z0-9]+",
+                text,
+            )
+    if code == "zh":
+        try:
+            import jieba
+
+            return [
+                word.strip().lower()
+                for word in jieba.cut(text)
+                if re.search(r"[\w\u3400-\u9fff]", word)
+            ]
+        except ImportError:
+            return re.findall(r"[\u3400-\u9fff]|[A-Za-z0-9]+", text)
     return re.findall(r"[A-Za-z0-9']+", text.lower())
 
 
@@ -43,28 +102,32 @@ def score_vocabulary_variety(words: list[str]) -> tuple[float, str]:
     return clamp_score(ratio * 100), f"unique_words={unique}; total_words={total}; ratio={ratio:.3f}"
 
 
-def score_response_length(words: list[str]) -> tuple[float, str]:
+def score_response_length(words: list[str], language: str) -> tuple[float, str]:
     total = len(words)
-    # 120 words is treated as a strong short reflection sample for V1.
-    return clamp_score((total / 120) * 100), f"total_words={total}"
+    target = {"en": 120, "ja": 100, "zh": 100}[language_code(language)]
+    return clamp_score((total / target) * 100), f"units={total}; target={target}"
 
 
-def score_sentence_complexity(words: list[str], sentences: list[str]) -> tuple[float, str]:
+def score_sentence_complexity(
+    text: str, words: list[str], sentences: list[str], language: str
+) -> tuple[float, str]:
     sentence_count = len(sentences)
     avg_len = len(words) / sentence_count if sentence_count else 0.0
-    connectors = {"and", "but", "because", "when", "while", "although", "if", "so"}
-    connector_count = sum(1 for word in words if word in connectors)
+    connectors = CONNECTORS[language_code(language)]
+    connector_count = sum(text.lower().count(connector) for connector in connectors)
     score = (min(avg_len, 20) / 20) * 70 + min(connector_count, 6) / 6 * 30
     return clamp_score(score), f"avg_sentence_length={avg_len:.2f}; connectors={connector_count}"
 
 
-def score_speech_pace(words: list[str], duration_seconds: float | None) -> tuple[float, str]:
+def score_speech_pace(
+    words: list[str], duration_seconds: float | None, language: str
+) -> tuple[float, str]:
     if not duration_seconds or duration_seconds <= 0:
         return 50.0, "duration_seconds=unknown; neutral_score_used=true"
-    words_per_minute = len(words) / duration_seconds * 60
-    # Center the V1 display around a broad conversational range.
-    score = 100 - abs(words_per_minute - 130) * 0.5
-    return clamp_score(score), f"words_per_minute={words_per_minute:.2f}"
+    units_per_minute = len(words) / duration_seconds * 60
+    center = {"en": 130, "ja": 110, "zh": 110}[language_code(language)]
+    score = 100 - abs(units_per_minute - center) * 0.5
+    return clamp_score(score), f"units_per_minute={units_per_minute:.2f}; center={center}"
 
 
 def score_pause_pattern() -> tuple[float, str]:
@@ -82,12 +145,11 @@ def score_repetition_pattern(words: list[str]) -> tuple[float, str]:
     return clamp_score(score), f"repeated_instances={repeated_instances}; ratio={ratio:.3f}"
 
 
-def score_emotional_tone(text: str) -> tuple[float, str]:
-    positive_words = {"good", "happy", "calm", "love", "great", "fine", "hope", "well"}
-    negative_words = {"bad", "sad", "angry", "tired", "worry", "worried", "fear", "pain"}
-    words = tokenize(text)
-    positive = sum(1 for word in words if word in positive_words)
-    negative = sum(1 for word in words if word in negative_words)
+def score_emotional_tone(text: str, language: str = "English") -> tuple[float, str]:
+    lexicon = EMOTION_WORDS[language_code(language)]
+    words = tokenize(text, language)
+    positive = sum(1 for word in words if word in lexicon["positive"])
+    negative = sum(1 for word in words if word in lexicon["negative"])
     total = positive + negative
     if total == 0:
         return 50.0, "positive_words=0; negative_words=0; neutral_score_used=true"
@@ -95,8 +157,8 @@ def score_emotional_tone(text: str) -> tuple[float, str]:
     return clamp_score(score), f"positive_words={positive}; negative_words={negative}"
 
 
-def score_transcription_clarity(text: str) -> tuple[float, str]:
-    words = tokenize(text)
+def score_transcription_clarity(text: str, language: str = "English") -> tuple[float, str]:
+    words = tokenize(text, language)
     if len(words) >= 20:
         return 90.0, f"recognized_words={len(words)}"
     if len(words) >= 8:
@@ -106,18 +168,25 @@ def score_transcription_clarity(text: str) -> tuple[float, str]:
     return 0.0, "recognized_words=0; transcript_empty=true"
 
 
-def calculate_feature_scores(text: str, duration_seconds: float | None = None) -> list[dict]:
-    words = tokenize(text)
+def calculate_feature_scores(
+    text: str,
+    duration_seconds: float | None = None,
+    language: str = "English",
+) -> list[dict]:
+    words = tokenize(text, language)
     sentences = split_sentences(text)
     score_builders = [
         ("Vocabulary Variety", lambda: score_vocabulary_variety(words)),
-        ("Response Length", lambda: score_response_length(words)),
-        ("Sentence Complexity", lambda: score_sentence_complexity(words, sentences)),
-        ("Speech Pace", lambda: score_speech_pace(words, duration_seconds)),
+        ("Response Length", lambda: score_response_length(words, language)),
+        (
+            "Sentence Complexity",
+            lambda: score_sentence_complexity(text, words, sentences, language),
+        ),
+        ("Speech Pace", lambda: score_speech_pace(words, duration_seconds, language)),
         ("Pause Pattern", score_pause_pattern),
         ("Repetition Pattern", lambda: score_repetition_pattern(words)),
-        ("Emotional Tone", lambda: score_emotional_tone(text)),
-        ("Transcription Clarity", lambda: score_transcription_clarity(text)),
+        ("Emotional Tone", lambda: score_emotional_tone(text, language)),
+        ("Transcription Clarity", lambda: score_transcription_clarity(text, language)),
     ]
     results = []
     for feature_name, builder in score_builders:

--- a/aoi_kinabot_app/speech_to_text.py
+++ b/aoi_kinabot_app/speech_to_text.py
@@ -1,26 +1,37 @@
-"""Speech-to-text helpers for KinaBot V1 audio uploads."""
+"""Private, server-local speech-to-text helpers for KinaBot."""
 
 from __future__ import annotations
 
 import os
 import tempfile
+from functools import lru_cache
 from pathlib import Path
 from typing import BinaryIO
 
-from config import OPENAI_TRANSCRIPTION_MODEL
 
-
-OPENAI_TRANSCRIPTION_TYPES = ["mp3", "mp4", "mpeg", "mpga", "m4a", "wav", "webm"]
+LOCAL_TRANSCRIPTION_TYPES = ["mp3", "mp4", "mpeg", "mpga", "m4a", "wav", "webm"]
 
 
 def speech_to_text_configured() -> bool:
-    return bool(os.getenv("OPENAI_API_KEY", "").strip())
+    """Local transcription is part of the app and needs no external API key."""
+    return True
 
 
-def transcribe_audio_upload(uploaded_file: BinaryIO, original_name: str) -> tuple[bool, str]:
-    if not speech_to_text_configured():
-        return False, "OPENAI_API_KEY is not configured."
+@lru_cache(maxsize=1)
+def _local_model():
+    from faster_whisper import WhisperModel
 
+    model_name = os.getenv("KINABOT_WHISPER_MODEL", "small")
+    compute_type = os.getenv("KINABOT_WHISPER_COMPUTE_TYPE", "int8")
+    return WhisperModel(model_name, device="cpu", compute_type=compute_type)
+
+
+def transcribe_audio_upload(
+    uploaded_file: BinaryIO,
+    original_name: str,
+    language_code: str,
+) -> tuple[bool, str, float | None]:
+    """Transcribe locally and delete the temporary audio file in every outcome."""
     suffix = Path(original_name).suffix or ".audio"
     temp_path: Path | None = None
     try:
@@ -28,19 +39,20 @@ def transcribe_audio_upload(uploaded_file: BinaryIO, original_name: str) -> tupl
             temp_path = Path(temp_file.name)
             temp_file.write(uploaded_file.getbuffer())
 
-        from openai import OpenAI
-
-        client = OpenAI()
-        with temp_path.open("rb") as audio_file:
-            transcript = client.audio.transcriptions.create(
-                model=OPENAI_TRANSCRIPTION_MODEL,
-                file=audio_file,
-                response_format="text",
-            )
-
-        return True, str(transcript).strip()
+        segments, info = _local_model().transcribe(
+            str(temp_path),
+            language=language_code,
+            beam_size=3,
+            vad_filter=True,
+            condition_on_previous_text=False,
+        )
+        text = " ".join(segment.text.strip() for segment in segments).strip()
+        if not text:
+            return False, "No clear speech was detected. Try a quieter recording.", None
+        duration = getattr(info, "duration", None)
+        return True, text, float(duration) if duration else None
     except Exception as exc:
-        return False, f"Speech-to-text failed: {exc}"
+        return False, f"Local speech-to-text failed: {exc}", None
     finally:
         if temp_path and temp_path.exists():
             temp_path.unlink()

--- a/aoi_kinabot_app/test_multilingual.py
+++ b/aoi_kinabot_app/test_multilingual.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+import database
+from language_analysis import LANGUAGE_CODES, analyze_transcript
+from insight_service import anonymous_trend_payload, generate_wellness_insight
+from scoring import calculate_feature_scores, tokenize
+from wellness_guidance import wellness_suggestions
+
+
+def test_supported_language_codes():
+    assert LANGUAGE_CODES == {"English": "en", "日本語": "ja", "中文": "zh"}
+
+
+def test_tokenization_supports_all_three_languages():
+    assert tokenize("A short English reflection.", "English")
+    assert tokenize("今日は家族と散歩しました。", "日本語")
+    assert tokenize("今天我和家人一起散步。", "中文")
+
+
+def test_local_nlp_scores_multilingual():
+    for language, text in [
+        ("English", "Today I spoke with my family and took a comfortable walk."),
+        ("日本語", "今日は家族と話してから、ゆっくり散歩しました。"),
+        ("中文", "今天我和家人聊天，然后慢慢散步。"),
+    ]:
+        scores, summary = analyze_transcript(text, language, 30)
+        assert len(scores) == 8
+        assert all(0 <= item["score"] <= 100 for item in scores)
+        assert summary
+
+
+def test_wellness_menu_is_not_selected_from_scores():
+    low = wellness_suggestions("English", [{"feature_name": "Expression Variety", "score": 5}])
+    high = wellness_suggestions("English", [{"feature_name": "Expression Variety", "score": 95}])
+    assert low["suggestions"] == high["suggestions"]
+    assert len(low["suggestions"]) == 3
+
+
+def test_habit_checkins_are_upserted(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(database, "DATABASE_PATH", tmp_path / "kina.sqlite3")
+    database.init_db()
+    user_id = database.upsert_user("test-user")
+    database.save_habit_checkins(
+        user_id,
+        "2026-07-28",
+        {"social_connection": True, "physical_activity": False},
+    )
+    database.save_habit_checkins(
+        user_id,
+        "2026-07-28",
+        {"social_connection": False, "physical_activity": True},
+    )
+    rows = database.get_user_habit_checkins(user_id)
+    values = {row["habit_name"]: row["completed"] for row in rows}
+    assert values == {"physical_activity": 1, "social_connection": 0}
+
+
+def test_calculate_feature_scores_accepts_language():
+    scores = calculate_feature_scores("今日は友人と話しました。", 20, "日本語")
+    assert len(scores) == 8
+
+
+def test_insight_payload_contains_scores_only(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    history = [
+        {
+            "created_at": f"2026-07-0{index}",
+            "session_number": 1,
+            "feature_name": "Vocabulary Variety",
+            "score": score,
+        }
+        for index, score in enumerate([72, 68, 61], start=1)
+    ]
+    payload = anonymous_trend_payload(history, "English")
+    assert set(payload) == {"language", "sessions_compared", "feature_scores"}
+    assert "email" not in str(payload).lower()
+    insight = generate_wellness_insight(history, "English")
+    assert insight["action"]
+    assert insight["source"].startswith("https://")

--- a/aoi_kinabot_app/wellness_guidance.py
+++ b/aoi_kinabot_app/wellness_guidance.py
@@ -1,0 +1,88 @@
+"""Evidence-aligned, non-diagnostic wellness suggestions for KinaBot."""
+
+from __future__ import annotations
+
+
+WHO_GUIDELINE = "https://www.who.int/publications/i/item/9789241550543"
+MEDITERRANEAN_TRIAL = "https://pubmed.ncbi.nlm.nih.gov/23670794/"
+SOCIAL_ENGAGEMENT_STUDY = "https://pmc.ncbi.nlm.nih.gov/articles/PMC6778491/"
+
+
+COPY = {
+    "English": {
+        "heading": "Optional wellness ideas",
+        "boundary": (
+            "These are general wellness ideas, not treatment and not conclusions "
+            "from your speech score. Choose what fits your health, abilities, and clinician's advice."
+        ),
+        "social": "Try a 10-minute conversation, shared story, or call with a friend or family member.",
+        "walk": "If it is safe for you, consider a comfortable walk or another physical activity you enjoy.",
+        "food": (
+            "Consider Mediterranean-style choices such as vegetables, legumes, whole grains, "
+            "fish, nuts, and olive oil. Check dietary changes with a clinician when appropriate."
+        ),
+    },
+    "日本語": {
+        "heading": "任意のウェルネス提案",
+        "boundary": (
+            "これは一般的な健康習慣の提案であり、治療や音声スコアからの診断ではありません。"
+            "体調・能力・医療専門家の助言に合うものを選んでください。"
+        ),
+        "social": "友人や家族と10分ほど会話したり、出来事を話したり、電話したりしてみましょう。",
+        "walk": "安全に行える場合は、無理のない散歩や好きな身体活動を検討してみましょう。",
+        "food": (
+            "野菜、豆類、全粒穀物、魚、ナッツ、オリーブ油などを取り入れた"
+            "地中海食に近い食事を検討できます。必要に応じて医療専門家に相談してください。"
+        ),
+    },
+    "中文": {
+        "heading": "可选的健康生活建议",
+        "boundary": (
+            "这些是一般健康生活建议，不是治疗，也不是根据语音分数作出的诊断。"
+            "请选择适合自己身体状况、能力及专业人员建议的做法。"
+        ),
+        "social": "可以尝试与朋友或家人交谈十分钟、分享一件往事，或者打一个电话。",
+        "walk": "如果对你来说安全，可以考虑舒适地散步，或进行自己喜欢的身体活动。",
+        "food": (
+            "可以考虑偏地中海式的饮食选择，例如蔬菜、豆类、全谷物、鱼、坚果和橄榄油。"
+            "如有特殊健康或饮食需求，请先咨询专业人员。"
+        ),
+    },
+}
+
+HABIT_LABELS = {
+    "English": {
+        "social_connection": "Connected with a friend or family member",
+        "physical_activity": "Did comfortable physical activity",
+        "mediterranean_style_meal": "Chose a Mediterranean-style meal",
+    },
+    "日本語": {
+        "social_connection": "友人や家族と交流した",
+        "physical_activity": "無理のない身体活動をした",
+        "mediterranean_style_meal": "地中海食に近い食事を選んだ",
+    },
+    "中文": {
+        "social_connection": "与朋友或家人进行了交流",
+        "physical_activity": "进行了舒适的身体活动",
+        "mediterranean_style_meal": "选择了偏地中海式的一餐",
+    },
+}
+
+
+def wellness_suggestions(language: str, scores: list[dict]) -> dict:
+    # Scores are intentionally not used to select or prioritize suggestions.
+    # KinaBot does not infer wellness state, cognitive change, risk, or cause
+    # from a speech sample. The ideas below are an independent optional menu.
+    del scores
+    copy = COPY.get(language, COPY["English"])
+    suggestions = [
+        {"text": copy["social"], "source": SOCIAL_ENGAGEMENT_STUDY},
+        {"text": copy["walk"], "source": WHO_GUIDELINE},
+        {"text": copy["food"], "source": MEDITERRANEAN_TRIAL},
+    ]
+    return {
+        "heading": copy["heading"],
+        "boundary": copy["boundary"],
+        "suggestions": suggestions[:3],
+        "habit_labels": HABIT_LABELS.get(language, HABIT_LABELS["English"]),
+    }


### PR DESCRIPTION
## What changed

- Separates the current Aoi-maintained application and architecture from historical root prototypes.
- Adds local/private transcription and versioned Python/NLP scoring for English, Japanese, and Chinese.
- Adds accounts, consent, longitudinal score storage, trends after three sessions, and optional habit check-ins.
- Adds a data-minimized OpenAI boundary: anonymous score histories only, never audio, transcripts, names, or email.
- Adds curated evidence-informed daily wellness actions with non-medical boundaries.
- Adds Docker and AWS-ready application packaging.

## Why

KinaBot's core value is its own repeatable multilingual NLP feature calculation
and personal longitudinal trends. OpenAI is limited to explaining an anonymous
score pattern as one practical daily wellness action; it is not a scoring
engine or medical assessor.

## Validation

- `pytest aoi_kinabot_app/test_multilingual.py -q` — 7 passed
- All Python files compiled with `py_compile`
- `git diff --check` passed

## Known V1 boundary

Pause-pattern extraction still uses a neutral placeholder and needs future
acoustic implementation and real-recording calibration. Scores are descriptive
wellness features, not clinically validated measures.
