### PR TITLE
Add timestamp-based pause analysis

### DIFF
--- a/aoi_kinabot_app/ARCHITECTURE.md
+++ b/aoi_kinabot_app/ARCHITECTURE.md
@@ -34,6 +34,7 @@ Optional OpenAI insight layer
 | Responsibility | Owner |
 |---|---|
 | Speech-to-text | Private/local transcription engine |
+| Pause and voiced-time extraction | KinaBot from local timestamped segments |
 | Linguistic and acoustic feature extraction | KinaBot Python/NLP |
 | Feature-score calculation | KinaBot versioned scoring engine |
 | Personal baseline and trend calculation | KinaBot application |

--- a/aoi_kinabot_app/README.md
+++ b/aoi_kinabot_app/README.md
@@ -132,7 +132,9 @@ streamlit run app.py
 ```
 
 Open the local URL shown by Streamlit, normally `http://localhost:8501`.
-Local transcription uses `faster-whisper`. The first analysis may take longer
+Local transcription uses `faster-whisper`. Timestamped speech segments are
+also used to calculate voiced duration, pause count, mean/maximum pause, and
+pause ratio. The first analysis may take longer
 while its model is downloaded and loaded; later analyses reuse the model.
 
 OpenAI is not required for transcription or NLP scoring. If the optional

--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -203,7 +203,12 @@ if st.button("3 · Analyze", type="primary", use_container_width=True):
     else:
         with st.status("Processing your recording…", expanded=True) as analysis_status:
             st.write("Transcribing privately on the KinaBot server…")
-            transcribed, transcript_or_error, detected_duration = transcribe_audio_upload(
+            (
+                transcribed,
+                transcript_or_error,
+                detected_duration,
+                acoustic_metrics,
+            ) = transcribe_audio_upload(
                 uploaded_audio,
                 uploaded_audio.name,
                 LANGUAGE_CODES[language],
@@ -218,6 +223,7 @@ if st.button("3 · Analyze", type="primary", use_container_width=True):
                 transcript_or_error,
                 language,
                 detected_duration,
+                acoustic_metrics,
             )
             audio_metadata = accept_audio_upload(uploaded_audio, uploaded_audio.name)
             session_number = tests_today + 1

--- a/aoi_kinabot_app/language_analysis.py
+++ b/aoi_kinabot_app/language_analysis.py
@@ -16,9 +16,15 @@ def analyze_transcript(
     transcript: str,
     language: str,
     duration_seconds: float | None,
+    acoustic_metrics: dict | None = None,
 ) -> tuple[list[dict], str]:
     """Calculate sample features locally; transcript text never leaves the server."""
-    scores = calculate_feature_scores(transcript, duration_seconds, language)
+    scores = calculate_feature_scores(
+        transcript,
+        duration_seconds,
+        language,
+        acoustic_metrics,
+    )
     summaries = {
         "English": "This summary describes observable patterns in this recording only.",
         "日本語": "この結果は、今回の録音で観察された特徴だけを表します。",

--- a/aoi_kinabot_app/scoring.py
+++ b/aoi_kinabot_app/scoring.py
@@ -130,9 +130,29 @@ def score_speech_pace(
     return clamp_score(score), f"units_per_minute={units_per_minute:.2f}; center={center}"
 
 
-def score_pause_pattern() -> tuple[float, str]:
-    # Placeholder until audio pause extraction is implemented.
-    return 50.0, "pause_analysis=v1_placeholder"
+def score_pause_pattern(acoustic_metrics: dict | None) -> tuple[float, str]:
+    if not acoustic_metrics:
+        return 50.0, "pause_analysis=unavailable; neutral_score_used=true"
+    pause_ratio = float(acoustic_metrics.get("pause_ratio", 0.0))
+    mean_pause = float(acoustic_metrics.get("mean_pause_seconds", 0.0))
+    # A broad descriptive center avoids treating one exact speaking style as ideal.
+    ratio_component = 100 - abs(pause_ratio - 0.25) * 140
+    duration_component = 100 - max(0.0, mean_pause - 1.5) * 18
+    score = ratio_component * 0.65 + duration_component * 0.35
+    raw = "; ".join(
+        f"{key}={value}"
+        for key, value in acoustic_metrics.items()
+        if key
+        in {
+            "voiced_seconds",
+            "pause_seconds",
+            "pause_count",
+            "mean_pause_seconds",
+            "max_pause_seconds",
+            "pause_ratio",
+        }
+    )
+    return clamp_score(score), raw
 
 
 def score_repetition_pattern(words: list[str]) -> tuple[float, str]:
@@ -172,6 +192,7 @@ def calculate_feature_scores(
     text: str,
     duration_seconds: float | None = None,
     language: str = "English",
+    acoustic_metrics: dict | None = None,
 ) -> list[dict]:
     words = tokenize(text, language)
     sentences = split_sentences(text)
@@ -183,7 +204,7 @@ def calculate_feature_scores(
             lambda: score_sentence_complexity(text, words, sentences, language),
         ),
         ("Speech Pace", lambda: score_speech_pace(words, duration_seconds, language)),
-        ("Pause Pattern", score_pause_pattern),
+        ("Pause Pattern", lambda: score_pause_pattern(acoustic_metrics)),
         ("Repetition Pattern", lambda: score_repetition_pattern(words)),
         ("Emotional Tone", lambda: score_emotional_tone(text, language)),
         ("Transcription Clarity", lambda: score_transcription_clarity(text, language)),

--- a/aoi_kinabot_app/speech_to_text.py
+++ b/aoi_kinabot_app/speech_to_text.py
@@ -30,7 +30,7 @@ def transcribe_audio_upload(
     uploaded_file: BinaryIO,
     original_name: str,
     language_code: str,
-) -> tuple[bool, str, float | None]:
+) -> tuple[bool, str, float | None, dict]:
     """Transcribe locally and delete the temporary audio file in every outcome."""
     suffix = Path(original_name).suffix or ".audio"
     temp_path: Path | None = None
@@ -39,20 +39,62 @@ def transcribe_audio_upload(
             temp_path = Path(temp_file.name)
             temp_file.write(uploaded_file.getbuffer())
 
-        segments, info = _local_model().transcribe(
+        segments_iter, info = _local_model().transcribe(
             str(temp_path),
             language=language_code,
             beam_size=3,
             vad_filter=True,
             condition_on_previous_text=False,
         )
+        segments = list(segments_iter)
         text = " ".join(segment.text.strip() for segment in segments).strip()
         if not text:
-            return False, "No clear speech was detected. Try a quieter recording.", None
+            return False, "No clear speech was detected. Try a quieter recording.", None, {}
         duration = getattr(info, "duration", None)
-        return True, text, float(duration) if duration else None
+        duration_seconds = float(duration) if duration else None
+        acoustic_metrics = calculate_pause_metrics(segments, duration_seconds)
+        return True, text, duration_seconds, acoustic_metrics
     except Exception as exc:
-        return False, f"Local speech-to-text failed: {exc}", None
+        return False, f"Local speech-to-text failed: {exc}", None, {}
     finally:
         if temp_path and temp_path.exists():
             temp_path.unlink()
+
+
+def calculate_pause_metrics(segments: list, duration_seconds: float | None) -> dict:
+    """Calculate descriptive pause metrics from timestamped speech segments."""
+    ordered = sorted(
+        (
+            (max(0.0, float(segment.start)), max(0.0, float(segment.end)))
+            for segment in segments
+            if float(segment.end) > float(segment.start)
+        ),
+        key=lambda item: item[0],
+    )
+    if not ordered:
+        return {}
+
+    voiced_seconds = sum(end - start for start, end in ordered)
+    pauses = [
+        max(0.0, ordered[index][0] - ordered[index - 1][1])
+        for index in range(1, len(ordered))
+    ]
+    meaningful_pauses = [pause for pause in pauses if pause >= 0.25]
+    total_duration = duration_seconds or ordered[-1][1]
+    pause_seconds = max(0.0, total_duration - voiced_seconds)
+    return {
+        "voiced_seconds": round(voiced_seconds, 3),
+        "pause_seconds": round(pause_seconds, 3),
+        "pause_count": len(meaningful_pauses),
+        "mean_pause_seconds": round(
+            sum(meaningful_pauses) / len(meaningful_pauses), 3
+        )
+        if meaningful_pauses
+        else 0.0,
+        "max_pause_seconds": round(max(meaningful_pauses), 3)
+        if meaningful_pauses
+        else 0.0,
+        "pause_ratio": round(pause_seconds / total_duration, 4)
+        if total_duration > 0
+        else 0.0,
+    }

--- a/aoi_kinabot_app/test_multilingual.py
+++ b/aoi_kinabot_app/test_multilingual.py
@@ -4,6 +4,7 @@ import database
 from language_analysis import LANGUAGE_CODES, analyze_transcript
 from insight_service import anonymous_trend_payload, generate_wellness_insight
 from scoring import calculate_feature_scores, tokenize
+from speech_to_text import calculate_pause_metrics
 from wellness_guidance import wellness_suggestions
 
 
@@ -77,3 +78,27 @@ def test_insight_payload_contains_scores_only(monkeypatch):
     insight = generate_wellness_insight(history, "English")
     assert insight["action"]
     assert insight["source"].startswith("https://")
+
+
+def test_pause_metrics_and_score_use_timestamps():
+    class Segment:
+        def __init__(self, start, end):
+            self.start = start
+            self.end = end
+
+    metrics = calculate_pause_metrics(
+        [Segment(0.0, 2.0), Segment(3.0, 5.0), Segment(6.5, 8.0)],
+        10.0,
+    )
+    assert metrics["pause_count"] == 2
+    assert metrics["max_pause_seconds"] == 1.5
+    assert metrics["pause_ratio"] == 0.45
+    scores = calculate_feature_scores(
+        "Today I spoke clearly about my day.",
+        10.0,
+        "English",
+        metrics,
+    )
+    pause = next(item for item in scores if item["feature_name"] == "Pause Pattern")
+    assert "pause_analysis=v1_placeholder" not in pause["raw_metric"]
+    assert 0 <= pause["score"] <= 100


### PR DESCRIPTION
## What changed

- calculates voiced duration from local Whisper timestamps
- calculates pause duration, count, mean pause, maximum pause, and pause ratio
- replaces the fixed neutral pause placeholder with a descriptive V1 score
- passes acoustic metrics through the local transcription and NLP pipeline
- documents the acoustic feature boundary

## Privacy

Audio and transcripts remain inside the local/private KinaBot processing
environment. OpenAI does not receive audio or transcript content.

## Validation

- multilingual and privacy tests: 8 passed
- all Python files compiled successfully
- Streamlit PC sign-in page executed without exceptions
