### PR TITLE
Document KinaBot ownership methodology and verifiable impact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 # Local KinaBot runtime data. The app recreates this folder/database locally.
 aoi_kinabot_app/data/
 aoi_kinabot_app/streamlit.*.log
+aoi_kinabot_app/kinabot-*.log

--- a/aoi_kinabot_app/ARCHITECTURE.md
+++ b/aoi_kinabot_app/ARCHITECTURE.md
@@ -5,6 +5,22 @@ This document applies only to the Aoi-maintained implementation in
 
 ## Data Flow
 
+```mermaid
+flowchart TD
+    A["Recording on user's phone or PC"] --> B["Temporary KinaBot processing copy"]
+    B --> C["Private/local Whisper transcription and timestamps"]
+    C --> D["English, Japanese, or Chinese NLP adapter"]
+    D --> E["Versioned Python feature scoring"]
+    E --> F["Store session metadata, raw metrics, and scores"]
+    B --> G["Delete temporary audio"]
+    C --> H["Discard full transcript"]
+    F --> I{"At least 3 sessions?"}
+    I -- No --> J["Show this sample only"]
+    I -- Yes --> K["Show personal descriptive trend"]
+    K --> L["Optional anonymous score-only insight request"]
+    L --> M["One evidence-bounded daily wellness action"]
+```
+
 ```text
 User's phone or PC
   └─ source recording remains on the user's device

--- a/aoi_kinabot_app/CHANGELOG.md
+++ b/aoi_kinabot_app/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to the current Aoi-maintained KinaBot application are
+recorded here. Historical repository-root prototypes are outside this
+changelog.
+
+## [1.1.0] - Unreleased
+
+### Added
+
+- English, Japanese, and Chinese language selection.
+- Language-specific tokenization with English rules, Janome for Japanese, and
+  jieba for Chinese.
+- Versioned, local Python/NLP feature scoring.
+- Private local transcription with `faster-whisper`.
+- Timestamp-derived voiced duration, pause count, pause duration, mean and
+  maximum pause, and pause ratio.
+- User accounts, email verification flow, consent records, session records,
+  feature-score history, and optional wellness habit check-ins.
+- Trend charts after at least three sessions.
+- A data-minimized optional OpenAI insight layer that receives anonymous score
+  histories and a curated action library, never audio, transcripts, names, or
+  email addresses.
+- Docker packaging and AWS production architecture documentation.
+- Automated multilingual, privacy-boundary, persistence, and pause-analysis
+  tests.
+
+### Changed
+
+- Replaced diagnosis-like and cognitive-age language with sample-level,
+  descriptive feature language.
+- Simplified the primary user journey to sign in, choose a language, select a
+  recording, analyze, and review results.
+- Separated the current implementation in `aoi_kinabot_app/` from historical
+  exploratory files elsewhere in the repository.
+
+### Privacy
+
+- Raw audio is processed through a temporary file and deleted on success or
+  failure.
+- Full transcripts are not persisted.
+- Feature scoring does not use OpenAI.
+
+## [1.0.1] - 2026-01-10
+
+- Historical repository release retained for provenance.
+
+## [1.0.0] - 2025-12-13
+
+- Initial historical repository release retained for provenance.

--- a/aoi_kinabot_app/IMPACT.md
+++ b/aoi_kinabot_app/IMPACT.md
@@ -1,0 +1,68 @@
+# KinaBot Verifiable Impact Record
+
+This page records only evidence that can be independently checked. It must not
+contain private user information, medical claims, estimated results, or
+promotional numbers without supporting records.
+
+## Public Repository Snapshot
+
+Snapshot date: 2026-07-28
+
+| Measure | Verified value | Verification |
+|---|---:|---|
+| GitHub stars | 8 | Public repository metadata |
+| GitHub forks | 2 | Public repository metadata |
+| GitHub watchers | 1 | Public repository metadata |
+| Aoi Minamoto contributions | 95 | GitHub contributors endpoint |
+| Public releases before V1.1 | 2 | GitHub releases |
+| Current application languages | 3 | Source, tests, and UI |
+| Automated application tests | 8 passing | Test run and GitHub Actions |
+
+Repository: [usekina/kina](https://github.com/usekina/kina)
+
+The figures above show public engineering activity and early external interest.
+They do not demonstrate clinical effectiveness or major significance in a
+professional field.
+
+## Product Evidence To Add After Verification
+
+The following table stays marked `Not yet reported` until evidence exists.
+
+| Measure | Current status | Acceptable supporting record |
+|---|---|---|
+| Registered pilot users | Not yet reported | De-identified database aggregate |
+| Weekly active users | Not yet reported | Dated analytics export |
+| 30-day retention | Not yet reported | Documented cohort calculation |
+| Completed voice reflections | Not yet reported | De-identified database aggregate |
+| Users completing 3+ sessions | Not yet reported | De-identified aggregate |
+| Institutional pilots | Not yet reported | Signed agreement or institution letter |
+| Independent expert evaluations | Not yet reported | Signed, dated expert letter |
+| Media coverage | Not yet reported | Independent publication URL/archive |
+| Research citations or downloads | Not yet reported | Publisher or repository analytics |
+| Awards or grants | Not yet reported | Issuer announcement and award record |
+
+## Evidence Update Rules
+
+1. Record the exact observation period and calculation method.
+2. Preserve the source export or document in the private evidence archive.
+3. Publish aggregate numbers only; never publish names, emails, recordings, or
+   transcripts.
+4. Distinguish users, registrations, sessions, and active users.
+5. Do not describe internal tests as independent adoption.
+6. Do not claim medical, diagnostic, preventive, or treatment outcomes.
+7. Correct public figures if later evidence shows an error, and record the
+   correction in the changelog.
+
+## Engineering Contributions
+
+The current public record documents Aoi Minamoto's work on:
+
+- the multilingual NLP scoring architecture;
+- the privacy separation between score calculation and generative insights;
+- longitudinal personal trend logic;
+- timestamp-based acoustic pause features;
+- consent and minimal-retention data design; and
+- Docker/AWS production preparation.
+
+Major-significance claims require independent corroboration beyond this
+self-maintained repository.

--- a/aoi_kinabot_app/OWNERSHIP-AND-MAINTAINERSHIP.md
+++ b/aoi_kinabot_app/OWNERSHIP-AND-MAINTAINERSHIP.md
@@ -1,0 +1,46 @@
+# Founder, Maintainer, and Contribution Record
+
+## Current Application
+
+- Product: KinaBot
+- Current implementation: `aoi_kinabot_app/`
+- Product founder and current maintainer: **Aoi Minamoto**
+- Current organization: **AImoji LLC**
+- Current public repository organization: **usekina**
+
+Aoi Minamoto directs the current product design, privacy model, multilingual
+NLP architecture, longitudinal experience, wellness-action boundaries, and
+deployment direction for the implementation in this folder.
+
+## Historical Work Boundary
+
+Files outside `aoi_kinabot_app/` are preserved as historical exploratory work.
+They must not be used to infer current maintainership, product claims, medical
+positioning, architecture, scoring methodology, or privacy behavior.
+
+## Authorship and Inventorship
+
+Git commit and pull-request history provide a dated engineering contribution
+record. Copyright authorship, repository maintainership, company ownership,
+and patent inventorship are different legal concepts.
+
+Patent inventorship must be determined claim by claim under applicable law.
+No person should be added or omitted merely because of a job title, repository
+role, code-assistance tool, or company relationship. Any future patent filing
+should be reviewed against dated design notes, commits, diagrams, and
+contributor records by qualified patent counsel.
+
+## Contribution Documentation
+
+Material future contributions should use:
+
+- an issue or dated design note describing the problem;
+- a feature branch and pull request;
+- named human contributors;
+- review and test records;
+- a changelog entry for released behavior; and
+- a written assignment or contributor agreement when required.
+
+AI-assisted drafting or coding does not replace human review. The responsible
+human maintainer must verify technical correctness, safety boundaries, and
+release decisions.

--- a/aoi_kinabot_app/README.md
+++ b/aoi_kinabot_app/README.md
@@ -53,7 +53,14 @@ normalization, testing, and calibration rather than treating English rules as
 universal.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) and
-[feature-score-design.md](feature-score-design.md).
+[SCORING-METHODOLOGY.md](SCORING-METHODOLOGY.md).
+
+Project records:
+
+- [Changelog](CHANGELOG.md)
+- [Verifiable impact](IMPACT.md)
+- [Founder and maintainership](OWNERSHIP-AND-MAINTAINERSHIP.md)
+- [V1.1 release checklist](RELEASE-CHECKLIST.md)
 
 ## OpenAI's Limited Role
 

--- a/aoi_kinabot_app/RELEASE-CHECKLIST.md
+++ b/aoi_kinabot_app/RELEASE-CHECKLIST.md
@@ -1,0 +1,44 @@
+# V1.1.0 Release Checklist
+
+## Engineering
+
+- [x] English, Japanese, and Chinese NLP paths
+- [x] Private/local transcription path
+- [x] Timestamp-based pause metrics
+- [x] Versioned score persistence
+- [x] Trends after three sessions
+- [x] Automated tests and GitHub Actions
+- [ ] Real English recording test
+- [ ] Real Japanese recording test
+- [ ] Real Chinese recording test
+- [ ] Production database migration
+- [ ] Account and history deletion
+
+## Privacy and Safety
+
+- [x] No persistent raw audio
+- [x] No persistent full transcript
+- [x] OpenAI excluded from transcription and scoring
+- [x] Anonymous score-only insight contract
+- [ ] Final public privacy notice reviewed
+- [ ] Production retention and deletion procedure tested
+- [ ] Research/pilot consent reviewed separately
+
+## Operations
+
+- [x] Dockerfile
+- [x] Health-check endpoint configuration
+- [ ] AWS ECS/RDS/SES/Secrets Manager deployment
+- [ ] HTTPS and stable production URL
+- [ ] Backup and restore test
+- [ ] Logging, monitoring, and alerting
+- [ ] Limited 5–10 user pilot before broader access
+
+## Evidence
+
+- [x] Maintainer and historical-work boundary
+- [x] Versioned methodology
+- [x] Public changelog
+- [x] Verifiable impact template
+- [ ] Store release test evidence in the private archive
+- [ ] Create GitHub release after this checklist's required V1.1 items pass

--- a/aoi_kinabot_app/SCORING-METHODOLOGY.md
+++ b/aoi_kinabot_app/SCORING-METHODOLOGY.md
@@ -1,0 +1,91 @@
+# KinaBot V1.1 Scoring Methodology
+
+Scoring model version: `score-v2-multilingual`
+
+## Purpose
+
+KinaBot produces repeatable, descriptive speech and language features for one
+voice sample and, after multiple sessions, shows changes relative to the same
+user's earlier samples.
+
+The scores are not medical measurements. They are not validated measures of
+intelligence, cognitive status, cognitive decline, disease, or risk.
+
+## Processing Boundary
+
+1. A user selects an audio file from a phone or computer.
+2. KinaBot creates a temporary working file.
+3. A private/local Whisper model produces a transcript and timestamps.
+4. KinaBot applies a language-specific NLP adapter.
+5. Python calculates raw metrics and 0–100 display scores.
+6. KinaBot stores the raw metrics, display scores, language, and scoring
+   version.
+7. The temporary audio and full transcript are discarded.
+
+OpenAI is not involved in transcription or feature scoring.
+
+## Language Adapters
+
+| Language | Segmentation | Language-specific inputs |
+|---|---|---|
+| English | Regular-expression word tokens | English connectors and emotional-expression vocabulary |
+| Japanese | Janome morphological analysis | Japanese connectors and emotional-expression vocabulary |
+| Chinese | jieba segmentation | Chinese connectors and emotional-expression vocabulary |
+
+Length and pace normalization use language-specific V1 reference centers.
+These engineering centers require further calibration with consented,
+representative recordings before broad interpretation.
+
+## Feature Set
+
+| Feature | Primary raw evidence |
+|---|---|
+| Vocabulary Variety | Unique units, total units, type-token ratio |
+| Response Length | Total language units relative to the language adapter |
+| Sentence Complexity | Units per sentence and discourse connectors |
+| Speech Pace | Language units per minute |
+| Pause Pattern | Voiced time, pause time/count, mean/maximum pause, pause ratio |
+| Repetition Pattern | Repeated units relative to total units |
+| Emotional Tone | Counts from a small language-specific expression lexicon |
+| Transcription Clarity | Amount of recognizable transcript evidence |
+
+## Longitudinal Display
+
+- Sessions 1–2: display the current sample only.
+- Session 3 onward: display descriptive history and first-to-latest
+  differences.
+- A difference is not automatically a meaningful personal change.
+- A lower score is not automatically a worse health state.
+- Changes may reflect topic, language choice, microphone, environment,
+  recording length, fatigue, mood, transcription error, or ordinary variation.
+
+## Versioning
+
+Every stored session includes:
+
+- application version;
+- consent version;
+- scoring-model version;
+- language; and
+- session metadata.
+
+Any future change to tokenization, reference centers, feature formulas, or
+feature definitions must increment the scoring-model version. Scores from
+different versions should not be placed on one uninterrupted trend line
+without a documented migration or recalculation method.
+
+## Validation Status
+
+V1.1 is an engineering and usability pilot. Automated tests verify code paths,
+ranges, language selection, data minimization, and timestamp-based pause
+calculation. They do not establish clinical validity.
+
+Future validation should include:
+
+- fluent-speaker review for every language;
+- repeat recordings under controlled and everyday conditions;
+- transcription error analysis;
+- device and microphone robustness testing;
+- test-retest reliability;
+- subgroup fairness review; and
+- documented calibration changes.


### PR DESCRIPTION
## What changed

- adds a V1.1 changelog and release checklist
- adds an impact record that separates verified public metrics from future evidence
- documents Aoi Minamoto's current founder/maintainer role and the boundary from historical prototypes
- documents the versioned multilingual scoring methodology and validation limits
- adds a Mermaid architecture diagram
- prevents local KinaBot test logs from entering Git

## Evidence integrity

The impact page reports only currently verifiable repository facts. Product
adoption, institutional use, expert evaluations, media, grants, and research
impact remain explicitly marked as not yet reported until corroborating
records exist.

## Validation

- multilingual/application tests: 8 passed
- `git diff --check` passed
- new private evidence-template repository verified as PRIVATE

## Deferred

- create `v1.1.0` only after this PR is merged and real English, Japanese, and
  Chinese recording checks are documented
- replace the temporary GitHub homepage with the production AWS URL after
  deployment
