### PR TITLE
Deploy simple KinaBot AWS staging service

### DIFF
--- a/aoi_kinabot_app/ARCHITECTURE.md
+++ b/aoi_kinabot_app/ARCHITECTURE.md
@@ -153,3 +153,9 @@ Route 53 / stable domain
 
 The deployment must use its own service, database, secrets, logs, and backups
 and must not overwrite an existing application.
+
+The initial pilot deployment uses one ECS task with encrypted EFS-backed
+SQLite to keep operations simple and persistent. It must remain single-task.
+RDS PostgreSQL is the required migration before horizontal scaling or
+materially higher concurrent write traffic. Deployment code is documented in
+[`aws/`](aws/README.md).

--- a/aoi_kinabot_app/Dockerfile
+++ b/aoi_kinabot_app/Dockerfile
@@ -4,7 +4,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     KINABOT_ENVIRONMENT=production \
     KINABOT_ALLOW_LOCAL_CODES=false \
-    KINABOT_DATABASE_PATH=/data/kinabot.sqlite3
+    KINABOT_DATABASE_PATH=/data/kinabot.sqlite3 \
+    HF_HOME=/models/huggingface
 
 WORKDIR /app
 
@@ -12,9 +13,9 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
-RUN mkdir -p /data
+RUN mkdir -p /data /models
 
-VOLUME ["/data"]
+VOLUME ["/data", "/models"]
 EXPOSE 8501
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \

--- a/aoi_kinabot_app/README.md
+++ b/aoi_kinabot_app/README.md
@@ -17,14 +17,15 @@ disease risk, estimate cognitive age, or replace professional care.
 
 ## Simple User Experience
 
-1. Sign in with an email verification code.
+1. Enter an email and a six-digit verification code on the same page.
 2. Choose English, Japanese, or Chinese.
 3. Select a recording stored on the user's phone or computer.
 4. Run one analysis and see that sample's feature scores.
 5. After three or more sessions, see personal trends and changes.
 6. Receive a small, practical daily wellness action when appropriate.
 
-The pilot allows up to two analyses per user per day.
+The pilot allows up to two analyses per verified email per day. Users do not
+create or remember a password.
 
 ## Core NLP Work
 

--- a/aoi_kinabot_app/RELEASE-CHECKLIST.md
+++ b/aoi_kinabot_app/RELEASE-CHECKLIST.md
@@ -28,7 +28,7 @@
 
 - [x] Dockerfile
 - [x] Health-check endpoint configuration
-- [ ] AWS ECS/RDS/SES/Secrets Manager deployment
+- [x] AWS ECS/ALB/EFS staging deployment
 - [ ] HTTPS and stable production URL
 - [ ] Backup and restore test
 - [ ] Logging, monitoring, and alerting

--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -75,37 +75,59 @@ if "user_id" not in st.session_state:
     st.session_state.user_id = None
 if "verified" not in st.session_state:
     st.session_state.verified = False
+if "code_sent" not in st.session_state:
+    st.session_state.code_sent = False
+if "staging_code" not in st.session_state:
+    st.session_state.staging_code = ""
 if not st.session_state.verified:
-    st.subheader("Sign in")
-    st.caption("We use your email to keep your private history together.")
+    st.subheader("Start")
+    st.caption("Enter an email to keep your scores and history together.")
     email = st.text_input("Email", value=st.session_state.email)
-    if st.button("Send code", use_container_width=True):
-        if not email.strip():
-            st.warning("Enter an email address first.")
+    if not st.session_state.code_sent:
+        send_code = st.button("Send code", type="primary", use_container_width=True)
+    else:
+        send_code = False
+    if send_code:
+        normalized_email = email.strip().lower()
+        if (
+            not normalized_email
+            or "@" not in normalized_email
+            or normalized_email.startswith("@")
+            or normalized_email.endswith("@")
+        ):
+            st.error("Enter a valid email address.")
         else:
-            st.session_state.email = email.strip()
-            _, code = create_local_verification_code(email)
-            sent, message = send_verification_email(st.session_state.email, code)
+            st.session_state.email = normalized_email
+            _, code = create_local_verification_code(normalized_email)
+            sent, message = send_verification_email(normalized_email, code)
             if sent:
+                st.session_state.code_sent = True
+                st.session_state.staging_code = ""
                 st.success(message)
+            elif ALLOW_LOCAL_VERIFICATION_CODES:
+                st.session_state.code_sent = True
+                st.session_state.staging_code = code
             else:
-                st.warning(message)
-                if ALLOW_LOCAL_VERIFICATION_CODES:
-                    st.info(f"Local dev code: {code}")
-                else:
-                    st.error("Email delivery is unavailable. Please try again later.")
-
-    code = st.text_input("6-digit code")
-    if st.button("Continue", type="primary", use_container_width=True):
-        email_hash = verify_code(email, code)
-        if not email_hash:
-            st.error("Invalid or expired code.")
-        else:
-            st.session_state.email = email.strip()
-            st.session_state.email_hash = email_hash
-            st.session_state.user_id = upsert_user(email_hash, email=st.session_state.email)
-            st.session_state.verified = True
+                st.error("Email delivery is unavailable. Please try again later.")
             st.rerun()
+
+    if st.session_state.code_sent:
+        if st.session_state.staging_code:
+            st.info(f"Private staging code: {st.session_state.staging_code}")
+        code = st.text_input("6-digit code", max_chars=6)
+        if st.button("Continue", type="primary", use_container_width=True):
+            email_hash = verify_code(st.session_state.email, code)
+            if not email_hash:
+                st.error("Invalid or expired code.")
+            else:
+                st.session_state.email_hash = email_hash
+                st.session_state.user_id = upsert_user(
+                    email_hash,
+                    email=st.session_state.email,
+                )
+                st.session_state.verified = True
+                st.session_state.staging_code = ""
+                st.rerun()
 
     st.caption("KinaBot is a wellness reflection tool, not a medical device.")
     st.stop()

--- a/aoi_kinabot_app/aws/README.md
+++ b/aoi_kinabot_app/aws/README.md
@@ -1,0 +1,65 @@
+# KinaBot Simple AWS Deployment
+
+This first deployment is intentionally small and independent from Term1:
+
+```text
+Docker image
+  → ECR
+  → one ECS Fargate task
+  → Application Load Balancer URL
+  → encrypted EFS for scores and the local Whisper model
+```
+
+CloudWatch receives application logs and EFS backup is enabled. All named
+resources use the `kinabot-` prefix.
+
+## First Private Test
+
+The initial stack runs in staging mode:
+
+- a user enters an email and six-digit code on the same page;
+- no password is created or remembered;
+- OpenAI is not configured;
+- no domain or certificate is required; and
+- the ALB supplies a temporary stable HTTP URL.
+
+During private infrastructure testing, the code can appear on screen. Before
+sharing the URL, connect Amazon SES so the code is delivered to the entered
+email and each verified email receives up to two analyses per day.
+
+## Deploy
+
+Prerequisites:
+
+```powershell
+aws login
+```
+
+Start Docker Desktop and wait until its engine is running. Then:
+
+```powershell
+cd "C:\Users\648493\OneDrive - TMNA\Desktop\Term1\kina_worktree\aoi_kinabot_app"
+.\aws\deploy.ps1
+```
+
+The script:
+
+1. confirms AWS and Docker;
+2. creates the separate `kinabot` ECR repository if needed;
+3. builds and pushes the container;
+4. finds two public subnets in the default VPC;
+5. deploys the independent `kinabot-production` stack; and
+6. prints the URL.
+
+## Before Inviting Users
+
+After the app works from the AWS URL:
+
+1. connect Amazon SES email-code delivery;
+2. disable on-screen staging codes and add HTTPS;
+3. generate a QR code for the AWS ALB URL;
+4. test data deletion and backup recovery; and
+5. invite 5–10 users before expanding.
+
+The first pilot uses one ECS task and EFS-backed SQLite. Keep the desired task
+count at one. Migrate to RDS PostgreSQL before horizontal scaling.

--- a/aoi_kinabot_app/aws/cloudformation.yml
+++ b/aoi_kinabot_app/aws/cloudformation.yml
@@ -1,0 +1,364 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Independent KinaBot V1.1 ECS Fargate service with ALB and encrypted EFS.
+
+Parameters:
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+  SubnetA:
+    Type: AWS::EC2::Subnet::Id
+  SubnetB:
+    Type: AWS::EC2::Subnet::Id
+  ContainerImage:
+    Type: String
+  CertificateArn:
+    Type: String
+    Default: ""
+    Description: Optional ACM certificate ARN. Leave blank for initial HTTP testing.
+  DesiredCount:
+    Type: Number
+    Default: 1
+    MinValue: 1
+    MaxValue: 1
+
+Conditions:
+  HasCertificate: !Not [!Equals [!Ref CertificateArn, ""]]
+
+Resources:
+  Cluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: kinabot-production
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+      Tags:
+        - Key: Application
+          Value: KinaBot
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /ecs/kinabot-production
+      RetentionInDays: 30
+
+  LoadBalancerSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Public HTTP and HTTPS access to KinaBot ALB
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Name
+          Value: kinabot-alb-sg
+
+  ServiceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: KinaBot task traffic from the ALB only
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 8501
+          ToPort: 8501
+          SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
+      Tags:
+        - Key: Name
+          Value: kinabot-service-sg
+
+  EfsSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: KinaBot task access to EFS
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 2049
+          ToPort: 2049
+          SourceSecurityGroupId: !Ref ServiceSecurityGroup
+      Tags:
+        - Key: Name
+          Value: kinabot-efs-sg
+
+  FileSystem:
+    Type: AWS::EFS::FileSystem
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Encrypted: true
+      BackupPolicy:
+        Status: ENABLED
+      FileSystemTags:
+        - Key: Name
+          Value: kinabot-production
+
+  MountTargetA:
+    Type: AWS::EFS::MountTarget
+    Properties:
+      FileSystemId: !Ref FileSystem
+      SubnetId: !Ref SubnetA
+      SecurityGroups:
+        - !Ref EfsSecurityGroup
+
+  MountTargetB:
+    Type: AWS::EFS::MountTarget
+    Properties:
+      FileSystemId: !Ref FileSystem
+      SubnetId: !Ref SubnetB
+      SecurityGroups:
+        - !Ref EfsSecurityGroup
+
+  DataAccessPoint:
+    Type: AWS::EFS::AccessPoint
+    Properties:
+      FileSystemId: !Ref FileSystem
+      PosixUser:
+        Uid: "1000"
+        Gid: "1000"
+      RootDirectory:
+        Path: /kinabot-data
+        CreationInfo:
+          OwnerUid: "1000"
+          OwnerGid: "1000"
+          Permissions: "0750"
+
+  ModelAccessPoint:
+    Type: AWS::EFS::AccessPoint
+    Properties:
+      FileSystemId: !Ref FileSystem
+      PosixUser:
+        Uid: "1000"
+        Gid: "1000"
+      RootDirectory:
+        Path: /whisper-models
+        CreationInfo:
+          OwnerUid: "1000"
+          OwnerGid: "1000"
+          Permissions: "0750"
+
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: kinabot-production
+      Scheme: internet-facing
+      SecurityGroups:
+        - !Ref LoadBalancerSecurityGroup
+      Subnets:
+        - !Ref SubnetA
+        - !Ref SubnetB
+      Tags:
+        - Key: Application
+          Value: KinaBot
+
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: kinabot-production
+      VpcId: !Ref VpcId
+      Port: 8501
+      Protocol: HTTP
+      TargetType: ip
+      HealthCheckEnabled: true
+      HealthCheckPath: /_stcore/health
+      HealthCheckIntervalSeconds: 30
+      HealthCheckTimeoutSeconds: 10
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 4
+      Matcher:
+        HttpCode: "200"
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: "30"
+
+  HttpListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - !If
+          - HasCertificate
+          - Type: redirect
+            RedirectConfig:
+              Protocol: HTTPS
+              Port: "443"
+              StatusCode: HTTP_301
+          - Type: forward
+            TargetGroupArn: !Ref TargetGroup
+
+  HttpsListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Condition: HasCertificate
+    Properties:
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 443
+      Protocol: HTTPS
+      Certificates:
+        - CertificateArn: !Ref CertificateArn
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref TargetGroup
+
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: kinabot-ecs-execution
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ecs-tasks.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
+  TaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: kinabot-task
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ecs-tasks.amazonaws.com
+            Action:
+              - sts:AssumeRole
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    DependsOn:
+      - MountTargetA
+      - MountTargetB
+    Properties:
+      Family: kinabot-production
+      RequiresCompatibilities:
+        - FARGATE
+      NetworkMode: awsvpc
+      Cpu: "4096"
+      Memory: "8192"
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      EphemeralStorage:
+        SizeInGiB: 30
+      Volumes:
+        - Name: kinabot-data
+          EFSVolumeConfiguration:
+            FilesystemId: !Ref FileSystem
+            TransitEncryption: ENABLED
+            AuthorizationConfig:
+              AccessPointId: !Ref DataAccessPoint
+              IAM: DISABLED
+        - Name: whisper-models
+          EFSVolumeConfiguration:
+            FilesystemId: !Ref FileSystem
+            TransitEncryption: ENABLED
+            AuthorizationConfig:
+              AccessPointId: !Ref ModelAccessPoint
+              IAM: DISABLED
+      ContainerDefinitions:
+        - Name: kinabot
+          Image: !Ref ContainerImage
+          Essential: true
+          PortMappings:
+            - ContainerPort: 8501
+              Protocol: tcp
+          Environment:
+            - Name: KINABOT_ENVIRONMENT
+              Value: staging
+            - Name: KINABOT_ALLOW_LOCAL_CODES
+              Value: "true"
+            - Name: KINABOT_DATABASE_PATH
+              Value: /data/kinabot.sqlite3
+            - Name: KINABOT_WHISPER_MODEL
+              Value: small
+            - Name: KINABOT_WHISPER_COMPUTE_TYPE
+              Value: int8
+            - Name: KINABOT_MAX_TESTS_PER_DAY
+              Value: "2"
+            - Name: KINABOT_MAX_AUDIO_MB
+              Value: "25"
+            - Name: HF_HOME
+              Value: /models/huggingface
+          MountPoints:
+            - SourceVolume: kinabot-data
+              ContainerPath: /data
+              ReadOnly: false
+            - SourceVolume: whisper-models
+              ContainerPath: /models
+              ReadOnly: false
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: app
+          HealthCheck:
+            Command:
+              - CMD-SHELL
+              - python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8501/_stcore/health', timeout=5)"
+            Interval: 30
+            Timeout: 10
+            Retries: 5
+            StartPeriod: 60
+
+  Service:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - HttpListener
+    Properties:
+      ServiceName: kinabot-production
+      Cluster: !Ref Cluster
+      TaskDefinition: !Ref TaskDefinition
+      DesiredCount: !Ref DesiredCount
+      LaunchType: FARGATE
+      PlatformVersion: LATEST
+      HealthCheckGracePeriodSeconds: 180
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 0
+        MaximumPercent: 100
+        DeploymentCircuitBreaker:
+          Enable: true
+          Rollback: true
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+            - !Ref ServiceSecurityGroup
+          Subnets:
+            - !Ref SubnetA
+            - !Ref SubnetB
+      LoadBalancers:
+        - ContainerName: kinabot
+          ContainerPort: 8501
+          TargetGroupArn: !Ref TargetGroup
+      Tags:
+        - Key: Application
+          Value: KinaBot
+
+Outputs:
+  LoadBalancerDnsName:
+    Value: !GetAtt LoadBalancer.DNSName
+  ApplicationUrl:
+    Value: !If
+      - HasCertificate
+      - !Sub https://${LoadBalancer.DNSName}
+      - !Sub http://${LoadBalancer.DNSName}
+  ClusterName:
+    Value: !Ref Cluster
+  ServiceName:
+    Value: !GetAtt Service.Name
+  FileSystemId:
+    Value: !Ref FileSystem

--- a/aoi_kinabot_app/aws/deploy.ps1
+++ b/aoi_kinabot_app/aws/deploy.ps1
@@ -1,0 +1,92 @@
+param(
+    [string]$Region = "us-west-2",
+    [string]$StackName = "kinabot-production",
+    [string]$RepositoryName = "kinabot",
+    [string]$CertificateArn = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$identity = aws sts get-caller-identity --region $Region | ConvertFrom-Json
+if (-not $identity.Account) {
+    throw "AWS authentication is not available. Run 'aws login' first."
+}
+
+docker version | Out-Null
+
+$accountId = $identity.Account
+$registry = "$accountId.dkr.ecr.$Region.amazonaws.com"
+$imageUri = "$registry/$RepositoryName`:latest"
+
+$previousErrorPreference = $ErrorActionPreference
+$ErrorActionPreference = "SilentlyContinue"
+aws ecr describe-repositories `
+    --repository-names $RepositoryName `
+    --region $Region 2>$null | Out-Null
+$repositoryExists = $LASTEXITCODE -eq 0
+$ErrorActionPreference = $previousErrorPreference
+if (-not $repositoryExists) {
+    aws ecr create-repository `
+        --repository-name $RepositoryName `
+        --image-scanning-configuration scanOnPush=true `
+        --encryption-configuration encryptionType=AES256 `
+        --region $Region | Out-Null
+}
+
+aws ecr get-login-password --region $Region |
+    docker login --username AWS --password-stdin $registry | Out-Null
+
+$appDirectory = Split-Path -Parent $PSScriptRoot
+docker build --pull --tag $imageUri $appDirectory
+docker push $imageUri
+
+$vpcId = aws ec2 describe-vpcs `
+    --filters Name=is-default,Values=true `
+    --query "Vpcs[0].VpcId" `
+    --output text `
+    --region $Region
+if (-not $vpcId -or $vpcId -eq "None") {
+    throw "No default VPC found. Pass an approved VPC by adapting this deployment."
+}
+
+$subnets = @(
+    aws ec2 describe-subnets `
+        --filters "Name=vpc-id,Values=$vpcId" `
+        --query "Subnets[?MapPublicIpOnLaunch==``true``].SubnetId" `
+        --output text `
+        --region $Region
+) -split "\s+"
+$subnets = @($subnets | Where-Object { $_ })
+if ($subnets.Count -lt 2) {
+    throw "At least two public subnets are required for the load balancer."
+}
+
+$parameterOverrides = @(
+    "VpcId=$vpcId",
+    "SubnetA=$($subnets[0])",
+    "SubnetB=$($subnets[1])",
+    "ContainerImage=$imageUri"
+)
+if ($CertificateArn) {
+    $parameterOverrides += "CertificateArn=$CertificateArn"
+}
+
+aws cloudformation deploy `
+    --template-file (Join-Path $PSScriptRoot "cloudformation.yml") `
+    --stack-name $StackName `
+    --capabilities CAPABILITY_NAMED_IAM `
+    --parameter-overrides $parameterOverrides `
+    --tags Application=KinaBot Environment=production `
+    --region $Region
+
+aws ecs update-service `
+    --cluster kinabot-production `
+    --service kinabot-production `
+    --force-new-deployment `
+    --region $Region | Out-Null
+
+aws cloudformation describe-stacks `
+    --stack-name $StackName `
+    --query "Stacks[0].Outputs" `
+    --output table `
+    --region $Region


### PR DESCRIPTION
## What this adds
- Simple AWS staging architecture using ECR, ECS Fargate, Application Load Balancer, encrypted EFS, CloudWatch Logs, and AWS Backup
- Same-page email and six-digit verification-code flow with no password
- Persistent application data and model cache volumes
- Docker and PowerShell deployment workflow
- Updated architecture, README, and release checklist

## Live staging verification
- URL: http://kinabot-production-259035011.us-west-2.elb.amazonaws.com
- Homepage: HTTP 200
- Health endpoint: HTTP 200 (ok)
- ECS service: 1 desired / 1 running, steady state
- Automated tests: 8 passed
- CloudFormation template validation: passed

## Staging limitations before inviting users
- Uses HTTP until HTTPS/domain configuration is added
- Verification code is shown on the page until email delivery is configured
- Real English, Japanese, and Chinese audio should be tested on the deployed service before public launch

This PR does not modify the existing Term1 application or its AWS resources.