### PR TITLE
Improve KinaBot mobile reflection and longitudinal UX

### DIFF
--- a/aoi_kinabot_app/CHANGELOG.md
+++ b/aoi_kinabot_app/CHANGELOG.md
@@ -31,8 +31,14 @@ changelog.
 - AWS Secrets Manager protection for the research-admin access key.
 - A data-minimized OpenAI Responses API connection using structured output,
   anonymous score histories, curated actions, and no response storage.
+- Returning-user profile restoration with name-based greeting.
+- Private age-range and gender fields plus aggregate profile counts for the
+  research admin view.
 
 ### Changed
+
+- Require one explicit daily wellness-habit selection instead of ambiguous
+  independent checkboxes.
 
 - Replaced diagnosis-like and cognitive-age language with sample-level,
   descriptive feature language.

--- a/aoi_kinabot_app/CHANGELOG.md
+++ b/aoi_kinabot_app/CHANGELOG.md
@@ -36,6 +36,8 @@ changelog.
   research admin view.
 - In-page browser microphone recording and a local four-dimension expression
   snapshot available from the first completed reflection.
+- Browser-timezone daily limits with UTC timestamps, local session dates, and
+  one-time correction of legacy UTC-dated sessions.
 
 ### Changed
 

--- a/aoi_kinabot_app/CHANGELOG.md
+++ b/aoi_kinabot_app/CHANGELOG.md
@@ -34,11 +34,15 @@ changelog.
 - Returning-user profile restoration with name-based greeting.
 - Private age-range and gender fields plus aggregate profile counts for the
   research admin view.
+- In-page browser microphone recording and a local four-dimension expression
+  snapshot available from the first completed reflection.
 
 ### Changed
 
 - Require one explicit daily wellness-habit selection instead of ambiguous
   independent checkboxes.
+- Present the reflection flow as language, record-or-upload, and analyze steps;
+  keep the eight technical features available in a compact details section.
 
 - Replaced diagnosis-like and cognitive-age language with sample-level,
   descriptive feature language.

--- a/aoi_kinabot_app/CHANGELOG.md
+++ b/aoi_kinabot_app/CHANGELOG.md
@@ -29,6 +29,8 @@ changelog.
 - A de-identified longitudinal research CSV export and a separate restricted
   user-management export.
 - AWS Secrets Manager protection for the research-admin access key.
+- A data-minimized OpenAI Responses API connection using structured output,
+  anonymous score histories, curated actions, and no response storage.
 
 ### Changed
 
@@ -38,6 +40,8 @@ changelog.
   recording, analyze, and review results.
 - Replaced percentage-like score rendering with mobile-friendly cards showing
   explicit `0–100` sample feature scores.
+- Increased the daily reflection limit from two to three so a user can unlock
+  the first personal trend chart in one day.
 - Separated the current implementation in `aoi_kinabot_app/` from historical
   exploratory files elsewhere in the repository.
 

--- a/aoi_kinabot_app/README.md
+++ b/aoi_kinabot_app/README.md
@@ -24,7 +24,7 @@ disease risk, estimate cognitive age, or replace professional care.
 5. After three or more sessions, see personal trends and changes.
 6. Receive a small, practical daily wellness action when appropriate.
 
-The pilot allows up to two analyses per verified email per day. Users do not
+The pilot allows up to three analyses per verified email per day. Users do not
 create or remember a password.
 
 ## Core NLP Work

--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -44,6 +44,7 @@ from speech_to_text import (
     transcribe_audio_upload,
 )
 from scoring import display_feature_name
+from reflection_profile import build_reflection_profile
 from wellness_guidance import wellness_suggestions
 
 
@@ -88,6 +89,24 @@ st.markdown(
     .score-card__explanation {
         color: rgba(49, 51, 63, 0.72);
         font-size: 0.9rem; line-height: 1.45; margin-top: 0.55rem;
+    }
+    .snapshot-card {
+        padding: 0.9rem 1rem; margin: 0.35rem 0;
+        border: 1px solid #f4d4c3; border-radius: 1rem;
+        background: linear-gradient(145deg, #fff7f1, #ffffff);
+    }
+    .snapshot-card__top {
+        display: flex; justify-content: space-between; align-items: center;
+    }
+    .snapshot-card__label {font-weight: 700; color: #303642;}
+    .snapshot-card__value {font-size: 1.25rem; font-weight: 750; color: #e65f3c;}
+    .snapshot-card__track {
+        height: 0.45rem; background: #f5e4dc; border-radius: 99px;
+        overflow: hidden; margin-top: 0.65rem;
+    }
+    .snapshot-card__fill {
+        height: 100%; background: linear-gradient(90deg, #f28a5c, #e55438);
+        border-radius: 99px;
     }
     </style>
     """,
@@ -365,37 +384,49 @@ language = st.radio(
     "1 · Choose the language spoken",
     ["English", "日本語", "中文"],
     horizontal=True,
-    help="Choose the language actually spoken in the uploaded recording.",
+    help="Choose the language you will speak in this recording.",
 )
 
 session_type = "Daily reflection"
-
-uploaded_audio = st.file_uploader(
-    "2 · Choose a recording from your phone or computer",
-    type=SUPPORTED_AUDIO_TYPES,
-    help="Supported local test formats: WAV, MP3, M4A, AAC, OGG, FLAC.",
+audio_method = st.radio(
+    "2 · Add your voice",
+    ["Record now", "Upload a recording"],
+    horizontal=True,
+    help="Record directly in the page, or use an audio file you already have.",
 )
 
-if uploaded_audio is not None:
-    st.audio(uploaded_audio)
-    st.caption(
-        f"Selected file: {uploaded_audio.name} "
-        f"({uploaded_audio.size / 1024:.1f} KB). Raw audio will not be stored by this app."
+if audio_method == "Record now":
+    selected_audio = st.audio_input(
+        "Tap the microphone, speak for 30–90 seconds, then stop",
     )
-    audio_extension = uploaded_audio.name.rsplit(".", 1)[-1].lower()
+    if selected_audio is None:
+        st.caption("Your browser may ask for microphone permission the first time.")
+else:
+    selected_audio = st.file_uploader(
+        "Choose a recording from your phone or computer",
+        type=SUPPORTED_AUDIO_TYPES,
+        help="Supported formats: WAV, MP3, M4A, AAC, OGG, and FLAC.",
+    )
+
+if selected_audio is not None:
+    st.audio(selected_audio)
+    st.caption(
+        f"Ready: {selected_audio.name} "
+        f"({selected_audio.size / 1024:.1f} KB). Raw audio will not be stored."
+    )
+    audio_extension = selected_audio.name.rsplit(".", 1)[-1].lower()
     can_transcribe = audio_extension in LOCAL_TRANSCRIPTION_TYPES
     if not can_transcribe:
         st.info(
-            "This file can be uploaded for local flow testing, but automatic transcription supports "
-            "MP3, MP4, MPEG, MPGA, M4A, WAV, and WEBM."
+            "Automatic transcription supports MP3, MP4, MPEG, MPGA, M4A, WAV, and WEBM."
         )
 st.caption(f"{max(0, remaining)} of {MAX_TESTS_PER_DAY} reflections available today")
-if st.button("3 · Analyze", type="primary", use_container_width=True):
-    if uploaded_audio is None:
-        st.warning("Upload a speech audio file first.")
-    elif uploaded_audio.size > MAX_AUDIO_BYTES:
+if st.button("3 · Analyze my reflection", type="primary", use_container_width=True):
+    if selected_audio is None:
+        st.warning("Record or upload a speech sample first.")
+    elif selected_audio.size > MAX_AUDIO_BYTES:
         st.warning(f"Audio must be {MAX_AUDIO_BYTES // (1024 * 1024)} MB or smaller.")
-    elif uploaded_audio.name.rsplit(".", 1)[-1].lower() not in LOCAL_TRANSCRIPTION_TYPES:
+    elif selected_audio.name.rsplit(".", 1)[-1].lower() not in LOCAL_TRANSCRIPTION_TYPES:
         st.warning("Use MP3, MP4, MPEG, MPGA, M4A, WAV, or WEBM for automatic analysis.")
     else:
         with st.status("Processing your recording…", expanded=True) as analysis_status:
@@ -406,8 +437,8 @@ if st.button("3 · Analyze", type="primary", use_container_width=True):
                 detected_duration,
                 acoustic_metrics,
             ) = transcribe_audio_upload(
-                uploaded_audio,
-                uploaded_audio.name,
+                selected_audio,
+                selected_audio.name,
                 LANGUAGE_CODES[language],
             )
             if not transcribed:
@@ -422,7 +453,7 @@ if st.button("3 · Analyze", type="primary", use_container_width=True):
                 detected_duration,
                 acoustic_metrics,
             )
-            audio_metadata = accept_audio_upload(uploaded_audio, uploaded_audio.name)
+            audio_metadata = accept_audio_upload(selected_audio, selected_audio.name)
             session_number = tests_today + 1
             test_session_id = create_test_session(
                 user_id=st.session_state.user_id,
@@ -462,27 +493,51 @@ if st.button("3 · Analyze", type="primary", use_container_width=True):
             },
         }[language]
         st.success(result_copy["saved"])
-        st.info(session_summary)
-        st.markdown(f"### {result_copy['title']}")
+        snapshot = build_reflection_profile(scores, language)
+        st.markdown(f"### {snapshot['title']}")
+        st.caption(snapshot["subtitle"])
+        snapshot_columns = st.columns(2)
+        for index, dimension in enumerate(snapshot["dimensions"]):
+            score = int(dimension["score"])
+            with snapshot_columns[index % 2]:
+                st.markdown(
+                    f"""
+                    <div class="snapshot-card">
+                      <div class="snapshot-card__top">
+                        <span class="snapshot-card__label">{dimension["label"]}</span>
+                        <span class="snapshot-card__value">{score}</span>
+                      </div>
+                      <div class="snapshot-card__track">
+                        <div class="snapshot-card__fill" style="width:{score}%"></div>
+                      </div>
+                    </div>
+                    """,
+                    unsafe_allow_html=True,
+                )
+        st.markdown(f"#### {snapshot['takeaway_title']}")
+        st.write(snapshot["takeaway"])
+        st.markdown(f"#### {snapshot['action_title']}")
+        st.info(snapshot["action"])
         st.caption(result_copy["scale"])
-        for item in scores:
-            score = int(round(float(item["score"])))
-            label = display_feature_name(item["feature_name"], language)
-            st.markdown(
-                f"""
-                <div class="score-card">
-                  <div class="score-card__top">
-                    <span class="score-card__name">{label}</span>
-                    <span class="score-card__value">{score} / 100</span>
-                  </div>
-                  <div class="score-card__track">
-                    <div class="score-card__fill" style="width:{score}%"></div>
-                  </div>
-                  <div class="score-card__explanation">{item["explanation"]}</div>
-                </div>
-                """,
-                unsafe_allow_html=True,
-            )
+        with st.expander(snapshot["detail_label"]):
+            for item in scores:
+                score = int(round(float(item["score"])))
+                label = display_feature_name(item["feature_name"], language)
+                st.markdown(
+                    f"""
+                    <div class="score-card">
+                      <div class="score-card__top">
+                        <span class="score-card__name">{label}</span>
+                        <span class="score-card__value">{score} / 100</span>
+                      </div>
+                      <div class="score-card__track">
+                        <div class="score-card__fill" style="width:{score}%"></div>
+                      </div>
+                      <div class="score-card__explanation">{item["explanation"]}</div>
+                    </div>
+                    """,
+                    unsafe_allow_html=True,
+                )
         st.caption(result_copy["boundary"])
 
 st.subheader("Your history")

--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -182,6 +182,34 @@ if ADMIN_KEY:
             research_df = pd.DataFrame(
                 [dict(row) for row in list_research_records()]
             )
+            if not users_df.empty:
+                with st.expander("Participant profile summary"):
+                    summary_rows = []
+                    for field, label in [
+                        ("age_range", "Age range"),
+                        ("gender", "Gender"),
+                        ("primary_language", "Primary language"),
+                        ("country_region", "Country / region"),
+                    ]:
+                        counts = (
+                            users_df[field]
+                            .fillna("Not provided")
+                            .replace("", "Not provided")
+                            .value_counts()
+                        )
+                        summary_rows.extend(
+                            {
+                                "field": label,
+                                "value": value,
+                                "users": int(count),
+                            }
+                            for value, count in counts.items()
+                        )
+                    st.dataframe(
+                        pd.DataFrame(summary_rows),
+                        hide_index=True,
+                        width="stretch",
+                    )
 
             st.download_button(
                 "Download research CSV",
@@ -216,6 +244,7 @@ if st.session_state.profile is None:
 profile = st.session_state.profile
 saved_name = (profile.get("display_name") or "").strip()
 age_options = ["Prefer not to say", "Under 30", "30-44", "45-59", "60-74", "75+"]
+gender_options = ["Prefer not to say", "Woman", "Man", "Non-binary", "Self-describe"]
 language_options = [
     "Prefer not to say",
     "English",
@@ -228,7 +257,13 @@ language_options = [
 if saved_name:
     st.markdown(f"### Welcome back, {saved_name}")
 
-with st.expander("Account settings" if saved_name else "Complete your account"):
+profile_complete = bool(
+    saved_name and profile.get("age_range") and profile.get("gender")
+)
+with st.expander(
+    "Account settings" if profile_complete else "Complete your account",
+    expanded=not profile_complete,
+):
     st.caption(st.session_state.email)
     display_name = st.text_input(
         "Name",
@@ -236,13 +271,24 @@ with st.expander("Account settings" if saved_name else "Complete your account"):
         placeholder="Your name",
     )
     age_range = st.selectbox(
-        "Age range (optional)",
+        "Age range",
         age_options,
         index=(
             age_options.index(profile.get("age_range"))
             if profile.get("age_range") in age_options
-            else 0
+            else None
         ),
+        placeholder="Select an age range",
+    )
+    gender = st.selectbox(
+        "Gender",
+        gender_options,
+        index=(
+            gender_options.index(profile.get("gender"))
+            if profile.get("gender") in gender_options
+            else None
+        ),
+        placeholder="Select a gender option",
     )
     primary_language = st.selectbox(
         "Primary language (optional)",
@@ -259,17 +305,25 @@ with st.expander("Account settings" if saved_name else "Complete your account"):
         placeholder="Example: US",
     )
     if st.button("Save account"):
-        update_user_profile(
-            st.session_state.user_id,
-            display_name.strip() or None,
-            None if age_range == "Prefer not to say" else age_range,
-            None if primary_language == "Prefer not to say" else primary_language,
-            country_region.strip() or None,
-        )
-        refreshed_profile = get_user_profile(st.session_state.user_id)
-        st.session_state.profile = dict(refreshed_profile) if refreshed_profile else {}
-        st.success("Account saved.")
-        st.rerun()
+        if not display_name.strip() or age_range is None or gender is None:
+            st.error("Please enter your name and select age range and gender.")
+        else:
+            update_user_profile(
+                st.session_state.user_id,
+                display_name.strip(),
+                age_range,
+                gender,
+                None if primary_language == "Prefer not to say" else primary_language,
+                country_region.strip() or None,
+            )
+            refreshed_profile = get_user_profile(st.session_state.user_id)
+            st.session_state.profile = dict(refreshed_profile) if refreshed_profile else {}
+            st.success("Account saved.")
+            st.rerun()
+
+if not profile_complete:
+    st.info("Complete your account once. KinaBot will remember it for future visits.")
+    st.stop()
 
 st.markdown(
     """
@@ -475,19 +529,30 @@ else:
         st.caption(f"{insight['why']} [Research source]({insight['source']})")
         st.caption(insight["boundary"])
 
-st.subheader("Optional wellness habits")
+st.subheader("Today's wellness habit")
 habit_copy = wellness_suggestions(language, [])
 st.caption(
-    "Optional habit tracking is separate from speech scores. KinaBot does not claim "
+    "Choose the one habit that best matches today. Habit tracking is separate from "
+    "speech scores. KinaBot does not claim "
     "that a habit caused any score or sample change."
 )
-habit_values = {
-    habit_name: st.checkbox(label, key=f"habit_{today}_{habit_name}")
-    for habit_name, label in habit_copy["habit_labels"].items()
-}
+habit_labels = habit_copy["habit_labels"]
+selected_habit_label = st.radio(
+    "Select one",
+    list(habit_labels.values()),
+    index=None,
+    key=f"habit_{today}",
+)
 if st.button("Save today's habit check-in"):
-    save_habit_checkins(st.session_state.user_id, today, habit_values)
-    st.success("Today's optional wellness habits were saved.")
+    if selected_habit_label is None:
+        st.error("Please select one habit.")
+    else:
+        selected_habit = next(
+            name for name, label in habit_labels.items() if label == selected_habit_label
+        )
+        habit_values = {name: name == selected_habit for name in habit_labels}
+        save_habit_checkins(st.session_state.user_id, today, habit_values)
+        st.success("Today's wellness habit was saved.")
 
 habit_rows = get_user_habit_checkins(st.session_state.user_id)
 if habit_rows:

--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -19,6 +19,7 @@ from config import (
     SCORING_MODEL_VERSION,
 )
 from database import (
+    assign_timezone_to_legacy_sessions,
     count_tests_today,
     create_test_session,
     get_admin_metrics,
@@ -38,6 +39,7 @@ from database import (
 from email_delivery import send_verification_email
 from insight_service import generate_wellness_insight
 from language_analysis import LANGUAGE_CODES, analyze_transcript
+from local_time import local_date_iso
 from speech_to_text import (
     LOCAL_TRANSCRIPTION_TYPES,
     speech_to_text_configured,
@@ -50,6 +52,8 @@ from wellness_guidance import wellness_suggestions
 
 st.set_page_config(page_title="KinaBot", page_icon="🎙️", layout="centered")
 init_db()
+browser_timezone = st.context.timezone or "UTC"
+today = local_date_iso(browser_timezone)
 
 st.markdown(
     """
@@ -368,7 +372,7 @@ if not consent:
 
 record_consent(st.session_state.user_id, CONSENT_VERSION)
 
-today = date.today().isoformat()
+assign_timezone_to_legacy_sessions(st.session_state.user_id, browser_timezone)
 tests_today = count_tests_today(st.session_state.user_id, today)
 remaining = MAX_TESTS_PER_DAY - tests_today
 if remaining <= 0:
@@ -465,6 +469,7 @@ if st.button("3 · Analyze my reflection", type="primary", use_container_width=T
                 session_type=session_type,
                 language=language,
                 duration_seconds=detected_duration or audio_metadata["duration_seconds"],
+                timezone_name=browser_timezone,
             )
             save_feature_scores(test_session_id, scores)
             analysis_status.update(label="Analysis complete", state="complete", expanded=False)

--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -23,6 +23,7 @@ from database import (
     create_test_session,
     get_admin_metrics,
     get_user_habit_checkins,
+    get_user_profile,
     get_user_scores,
     init_db,
     list_admin_test_records,
@@ -108,6 +109,8 @@ if "code_sent" not in st.session_state:
     st.session_state.code_sent = False
 if "staging_code" not in st.session_state:
     st.session_state.staging_code = ""
+if "profile" not in st.session_state:
+    st.session_state.profile = None
 if not st.session_state.verified:
     st.subheader("Start")
     st.caption("Enter an email to keep your scores and history together.")
@@ -154,6 +157,8 @@ if not st.session_state.verified:
                     email_hash,
                     email=st.session_state.email,
                 )
+                profile = get_user_profile(st.session_state.user_id)
+                st.session_state.profile = dict(profile) if profile else {}
                 st.session_state.verified = True
                 st.session_state.staging_code = ""
                 st.rerun()
@@ -204,18 +209,55 @@ if ADMIN_KEY:
             st.warning("Invalid admin key.")
 
 
-with st.expander("Account"):
+if st.session_state.profile is None:
+    profile = get_user_profile(st.session_state.user_id)
+    st.session_state.profile = dict(profile) if profile else {}
+
+profile = st.session_state.profile
+saved_name = (profile.get("display_name") or "").strip()
+age_options = ["Prefer not to say", "Under 30", "30-44", "45-59", "60-74", "75+"]
+language_options = [
+    "Prefer not to say",
+    "English",
+    "Japanese",
+    "Chinese",
+    "Spanish",
+    "Other",
+]
+
+if saved_name:
+    st.markdown(f"### Welcome back, {saved_name}")
+
+with st.expander("Account settings" if saved_name else "Complete your account"):
     st.caption(st.session_state.email)
-    display_name = st.text_input("Name", placeholder="Your name")
+    display_name = st.text_input(
+        "Name",
+        value=saved_name,
+        placeholder="Your name",
+    )
     age_range = st.selectbox(
         "Age range (optional)",
-        ["Prefer not to say", "Under 30", "30-44", "45-59", "60-74", "75+"],
+        age_options,
+        index=(
+            age_options.index(profile.get("age_range"))
+            if profile.get("age_range") in age_options
+            else 0
+        ),
     )
     primary_language = st.selectbox(
         "Primary language (optional)",
-        ["Prefer not to say", "English", "Japanese", "Chinese", "Spanish", "Other"],
+        language_options,
+        index=(
+            language_options.index(profile.get("primary_language"))
+            if profile.get("primary_language") in language_options
+            else 0
+        ),
     )
-    country_region = st.text_input("Country / region (optional)", placeholder="Example: US")
+    country_region = st.text_input(
+        "Country / region (optional)",
+        value=profile.get("country_region") or "",
+        placeholder="Example: US",
+    )
     if st.button("Save account"):
         update_user_profile(
             st.session_state.user_id,
@@ -224,7 +266,10 @@ with st.expander("Account"):
             None if primary_language == "Prefer not to say" else primary_language,
             country_region.strip() or None,
         )
+        refreshed_profile = get_user_profile(st.session_state.user_id)
+        st.session_state.profile = dict(refreshed_profile) if refreshed_profile else {}
         st.success("Account saved.")
+        st.rerun()
 
 st.markdown(
     """

--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -231,8 +231,10 @@ st.markdown(
     <div class="privacy-card">
       <strong>Your recording is not saved.</strong><br>
       Your selected file is processed privately on the KinaBot server with local Python,
-      then the temporary copy is deleted. It is not sent to OpenAI. KinaBot stores your account, scores, usage
-      history, and optional habit check-ins—not the raw audio or full transcript.
+      then the temporary copy is deleted. Raw audio and full transcripts are not
+      sent to OpenAI. After three sessions, only anonymous score history may be
+      used to select a general wellness action. KinaBot stores your account, scores,
+      usage history, and optional habit check-ins—not the raw audio or full transcript.
     </div>
     """,
     unsafe_allow_html=True,
@@ -252,7 +254,10 @@ today = date.today().isoformat()
 tests_today = count_tests_today(st.session_state.user_id, today)
 remaining = MAX_TESTS_PER_DAY - tests_today
 if remaining <= 0:
-    st.info("You have completed today's two reflections. Come back tomorrow.")
+    st.info(
+        f"You have completed today's {MAX_TESTS_PER_DAY} reflections. "
+        "Come back tomorrow."
+    )
     st.stop()
 
 st.subheader("New reflection")

--- a/aoi_kinabot_app/aws/README.md
+++ b/aoi_kinabot_app/aws/README.md
@@ -19,13 +19,13 @@ The initial stack runs in staging mode:
 
 - a user enters an email and six-digit code on the same page;
 - no password is created or remembered;
-- OpenAI is not configured;
+- OpenAI is connected only to anonymous score trends and curated actions;
 - no domain or certificate is required; and
 - the ALB supplies a temporary stable HTTP URL.
 
 During private infrastructure testing, the code can appear on screen. Before
 sharing the URL, connect Amazon SES so the code is delivered to the entered
-email and each verified email receives up to two analyses per day.
+email and each verified email receives up to three analyses per day.
 
 ## Deploy
 

--- a/aoi_kinabot_app/aws/cloudformation.yml
+++ b/aoi_kinabot_app/aws/cloudformation.yml
@@ -243,7 +243,7 @@ Resources:
             - HEAD
             - OPTIONS
           Compress: true
-          CachePolicyId: 413f39a6-2a92-4bd5-9dc2-5f8e2b5a7a2e
+          CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad
           OriginRequestPolicyId: 216adef6-5c7f-47e4-b989-5492eafa07d3
 
   ExecutionRole:

--- a/aoi_kinabot_app/aws/cloudformation.yml
+++ b/aoi_kinabot_app/aws/cloudformation.yml
@@ -210,6 +210,42 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref TargetGroup
 
+  HttpsDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Comment: KinaBot secure mobile web entry point
+        Enabled: true
+        HttpVersion: http2and3
+        IPV6Enabled: true
+        PriceClass: PriceClass_100
+        Origins:
+          - Id: KinaBotAlb
+            DomainName: !GetAtt LoadBalancer.DNSName
+            CustomOriginConfig:
+              HTTPPort: 80
+              OriginProtocolPolicy: http-only
+              OriginReadTimeout: 60
+              OriginKeepaliveTimeout: 5
+        DefaultCacheBehavior:
+          TargetOriginId: KinaBotAlb
+          ViewerProtocolPolicy: redirect-to-https
+          AllowedMethods:
+            - DELETE
+            - GET
+            - HEAD
+            - OPTIONS
+            - PATCH
+            - POST
+            - PUT
+          CachedMethods:
+            - GET
+            - HEAD
+            - OPTIONS
+          Compress: true
+          CachePolicyId: 413f39a6-2a92-4bd5-9dc2-5f8e2b5a7a2e
+          OriginRequestPolicyId: 216adef6-5c7f-47e4-b989-5492eafa07d3
+
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -389,6 +425,9 @@ Outputs:
       - HasCertificate
       - !Sub https://${LoadBalancer.DNSName}
       - !Sub http://${LoadBalancer.DNSName}
+  SecureApplicationUrl:
+    Description: HTTPS URL required for in-browser microphone recording.
+    Value: !Sub https://${HttpsDistribution.DomainName}
   ClusterName:
     Value: !Ref Cluster
   ServiceName:

--- a/aoi_kinabot_app/aws/cloudformation.yml
+++ b/aoi_kinabot_app/aws/cloudformation.yml
@@ -10,6 +10,9 @@ Parameters:
     Type: AWS::EC2::Subnet::Id
   ContainerImage:
     Type: String
+  OpenAIApiKeySecretArn:
+    Type: String
+    Description: Existing Secrets Manager ARN containing the KinaBot OpenAI project API key.
   CertificateArn:
     Type: String
     Default: ""
@@ -230,7 +233,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - secretsmanager:GetSecretValue
-                Resource: !Ref AdminKeySecret
+                Resource:
+                  - !Ref AdminKeySecret
+                  - !Ref OpenAIApiKeySecretArn
 
   AdminKeySecret:
     Type: AWS::SecretsManager::Secret
@@ -308,7 +313,9 @@ Resources:
             - Name: KINABOT_WHISPER_COMPUTE_TYPE
               Value: int8
             - Name: KINABOT_MAX_TESTS_PER_DAY
-              Value: "2"
+              Value: "3"
+            - Name: KINABOT_INSIGHT_MODEL
+              Value: gpt-5.6-luna
             - Name: KINABOT_MAX_AUDIO_MB
               Value: "25"
             - Name: HF_HOME
@@ -316,6 +323,8 @@ Resources:
           Secrets:
             - Name: KINABOT_ADMIN_KEY
               ValueFrom: !Ref AdminKeySecret
+            - Name: OPENAI_API_KEY
+              ValueFrom: !Ref OpenAIApiKeySecretArn
           MountPoints:
             - SourceVolume: kinabot-data
               ContainerPath: /data

--- a/aoi_kinabot_app/config.py
+++ b/aoi_kinabot_app/config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 APP_VERSION = "v1.1-multilingual-pilot"
 CONSENT_VERSION = "consent-v1.1"
 SCORING_MODEL_VERSION = "score-v2-multilingual"
-OPENAI_INSIGHT_MODEL = os.getenv("KINABOT_INSIGHT_MODEL", "gpt-4.1-mini")
+OPENAI_INSIGHT_MODEL = os.getenv("KINABOT_INSIGHT_MODEL", "gpt-5.6-luna")
 ENVIRONMENT = os.getenv("KINABOT_ENVIRONMENT", "development").strip().lower()
 ALLOW_LOCAL_VERIFICATION_CODES = (
     os.getenv("KINABOT_ALLOW_LOCAL_CODES", "true").strip().lower() == "true"
@@ -20,7 +20,7 @@ DATABASE_PATH = Path(
     os.getenv("KINABOT_DATABASE_PATH", str(DATA_DIR / "kinabot_v1.sqlite3"))
 )
 
-MAX_TESTS_PER_DAY = int(os.getenv("KINABOT_MAX_TESTS_PER_DAY", "2"))
+MAX_TESTS_PER_DAY = int(os.getenv("KINABOT_MAX_TESTS_PER_DAY", "3"))
 MAX_AUDIO_BYTES = int(os.getenv("KINABOT_MAX_AUDIO_MB", "25")) * 1024 * 1024
 VERIFICATION_CODE_TTL_MINUTES = 10
 

--- a/aoi_kinabot_app/data-and-access-design.md
+++ b/aoi_kinabot_app/data-and-access-design.md
@@ -51,7 +51,7 @@ Each verified user may complete:
 
 Each test should create one test record.
 
-If a user completes two tests on the same day, the records should be labeled:
+If a user completes three tests on the same day, the records should be labeled:
 
 - Session 1
 - Session 2
@@ -130,7 +130,7 @@ The system should support trend views over:
 
 Each feature score can be shown as a line chart over time.
 
-For users with two tests in one day:
+For users with three tests in one day:
 
 - Both points should be shown on the chart
 - Session 1 and Session 2 should be distinguishable

--- a/aoi_kinabot_app/database.py
+++ b/aoi_kinabot_app/database.py
@@ -131,6 +131,19 @@ def upsert_user(email_hash: str, email: str | None = None) -> int:
         return int(row["id"])
 
 
+def get_user_profile(user_id: int) -> sqlite3.Row | None:
+    with get_connection() as conn:
+        return conn.execute(
+            """
+            SELECT id, email, display_name, age_range, primary_language,
+                   country_region
+            FROM users
+            WHERE id = ?
+            """,
+            (user_id,),
+        ).fetchone()
+
+
 def update_user_profile(
     user_id: int,
     display_name: str | None,

--- a/aoi_kinabot_app/database.py
+++ b/aoi_kinabot_app/database.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Iterable
 
 from config import DATABASE_PATH
+from local_time import utc_iso_to_local_date
 
 
 def utc_now_iso() -> str:
@@ -41,6 +42,7 @@ def init_db() -> None:
                 gender TEXT,
                 primary_language TEXT,
                 country_region TEXT,
+                timezone_name TEXT,
                 created_at TEXT NOT NULL,
                 last_active_at TEXT
             );
@@ -70,6 +72,7 @@ def init_db() -> None:
                 session_type TEXT,
                 language TEXT,
                 duration_seconds REAL,
+                timezone_name TEXT,
                 app_version TEXT NOT NULL,
                 consent_version TEXT NOT NULL,
                 scoring_model_version TEXT NOT NULL,
@@ -107,9 +110,11 @@ def init_db() -> None:
         ensure_column(conn, "users", "gender", "TEXT")
         ensure_column(conn, "users", "primary_language", "TEXT")
         ensure_column(conn, "users", "country_region", "TEXT")
+        ensure_column(conn, "users", "timezone_name", "TEXT")
         ensure_column(conn, "test_sessions", "session_type", "TEXT")
         ensure_column(conn, "test_sessions", "language", "TEXT")
         ensure_column(conn, "test_sessions", "duration_seconds", "REAL")
+        ensure_column(conn, "test_sessions", "timezone_name", "TEXT")
 
 
 def upsert_user(email_hash: str, email: str | None = None) -> int:
@@ -138,7 +143,7 @@ def get_user_profile(user_id: int) -> sqlite3.Row | None:
         return conn.execute(
             """
             SELECT id, email, display_name, age_range, gender, primary_language,
-                   country_region
+                   country_region, timezone_name
             FROM users
             WHERE id = ?
             """,
@@ -240,6 +245,54 @@ def count_tests_today(user_id: int, session_date: str) -> int:
         return int(row["count"])
 
 
+def assign_timezone_to_legacy_sessions(user_id: int, timezone_name: str) -> int:
+    """Rebucket legacy UTC-dated sessions once using the user's browser zone."""
+    with get_connection() as conn:
+        conn.execute(
+            "UPDATE users SET timezone_name = ?, last_active_at = ? WHERE id = ?",
+            (timezone_name, utc_now_iso(), user_id),
+        )
+        rows = conn.execute(
+            """
+            SELECT id, created_at
+            FROM test_sessions
+            WHERE user_id = ?
+              AND (timezone_name IS NULL OR timezone_name = '')
+            ORDER BY created_at ASC, id ASC
+            """,
+            (user_id,),
+        ).fetchall()
+        for row in rows:
+            local_date = utc_iso_to_local_date(row["created_at"], timezone_name)
+            conn.execute(
+                """
+                UPDATE test_sessions
+                SET session_date = ?, timezone_name = ?
+                WHERE id = ?
+                """,
+                (local_date, timezone_name, row["id"]),
+            )
+
+        dated_rows = conn.execute(
+            """
+            SELECT id, session_date
+            FROM test_sessions
+            WHERE user_id = ?
+            ORDER BY session_date ASC, created_at ASC, id ASC
+            """,
+            (user_id,),
+        ).fetchall()
+        counters: dict[str, int] = {}
+        for row in dated_rows:
+            session_date = str(row["session_date"])
+            counters[session_date] = counters.get(session_date, 0) + 1
+            conn.execute(
+                "UPDATE test_sessions SET session_number = ? WHERE id = ?",
+                (counters[session_date], row["id"]),
+            )
+        return len(rows)
+
+
 def create_test_session(
     user_id: int,
     session_date: str,
@@ -250,15 +303,16 @@ def create_test_session(
     session_type: str | None = None,
     language: str | None = None,
     duration_seconds: float | None = None,
+    timezone_name: str | None = None,
 ) -> int:
     with get_connection() as conn:
         cursor = conn.execute(
             """
             INSERT INTO test_sessions
                 (user_id, session_date, session_number, session_type, language,
-                 duration_seconds, app_version, consent_version,
+                 duration_seconds, timezone_name, app_version, consent_version,
                  scoring_model_version, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 user_id,
@@ -267,6 +321,7 @@ def create_test_session(
                 session_type,
                 language,
                 duration_seconds,
+                timezone_name,
                 app_version,
                 consent_version,
                 scoring_model_version,
@@ -371,7 +426,7 @@ def list_admin_users() -> list[sqlite3.Row]:
         return conn.execute(
             """
             SELECT id, email, display_name, age_range, gender, primary_language,
-                   country_region, created_at, last_active_at
+                   country_region, timezone_name, created_at, last_active_at
             FROM users
             ORDER BY created_at DESC
             """
@@ -394,6 +449,7 @@ def list_admin_test_records() -> list[sqlite3.Row]:
                 ts.session_type,
                 ts.language,
                 ts.duration_seconds,
+                ts.timezone_name,
                 fs.feature_name,
                 fs.score,
                 fs.raw_metric
@@ -423,6 +479,7 @@ def list_research_records() -> list[sqlite3.Row]:
                 ts.session_type,
                 ts.language,
                 ts.duration_seconds,
+                ts.timezone_name,
                 ts.app_version,
                 ts.consent_version,
                 ts.scoring_model_version,

--- a/aoi_kinabot_app/database.py
+++ b/aoi_kinabot_app/database.py
@@ -38,6 +38,7 @@ def init_db() -> None:
                 email TEXT,
                 display_name TEXT,
                 age_range TEXT,
+                gender TEXT,
                 primary_language TEXT,
                 country_region TEXT,
                 created_at TEXT NOT NULL,
@@ -103,6 +104,7 @@ def init_db() -> None:
         ensure_column(conn, "users", "email", "TEXT")
         ensure_column(conn, "users", "display_name", "TEXT")
         ensure_column(conn, "users", "age_range", "TEXT")
+        ensure_column(conn, "users", "gender", "TEXT")
         ensure_column(conn, "users", "primary_language", "TEXT")
         ensure_column(conn, "users", "country_region", "TEXT")
         ensure_column(conn, "test_sessions", "session_type", "TEXT")
@@ -135,7 +137,7 @@ def get_user_profile(user_id: int) -> sqlite3.Row | None:
     with get_connection() as conn:
         return conn.execute(
             """
-            SELECT id, email, display_name, age_range, primary_language,
+            SELECT id, email, display_name, age_range, gender, primary_language,
                    country_region
             FROM users
             WHERE id = ?
@@ -148,6 +150,7 @@ def update_user_profile(
     user_id: int,
     display_name: str | None,
     age_range: str | None,
+    gender: str | None,
     primary_language: str | None,
     country_region: str | None,
 ) -> None:
@@ -155,13 +158,14 @@ def update_user_profile(
         conn.execute(
             """
             UPDATE users
-            SET display_name = ?, age_range = ?, primary_language = ?,
+            SET display_name = ?, age_range = ?, gender = ?, primary_language = ?,
                 country_region = ?, last_active_at = ?
             WHERE id = ?
             """,
             (
                 display_name,
                 age_range,
+                gender,
                 primary_language,
                 country_region,
                 utc_now_iso(),
@@ -366,7 +370,7 @@ def list_admin_users() -> list[sqlite3.Row]:
     with get_connection() as conn:
         return conn.execute(
             """
-            SELECT id, email, display_name, age_range, primary_language,
+            SELECT id, email, display_name, age_range, gender, primary_language,
                    country_region, created_at, last_active_at
             FROM users
             ORDER BY created_at DESC
@@ -382,6 +386,7 @@ def list_admin_test_records() -> list[sqlite3.Row]:
                 u.email,
                 u.display_name,
                 u.age_range,
+                u.gender,
                 u.primary_language,
                 u.country_region,
                 ts.created_at,
@@ -408,6 +413,7 @@ def list_research_records() -> list[sqlite3.Row]:
             SELECT
                 printf('P%06d', u.id) AS participant_id,
                 u.age_range,
+                u.gender,
                 u.primary_language,
                 u.country_region,
                 ts.id AS session_id,

--- a/aoi_kinabot_app/insight_service.py
+++ b/aoi_kinabot_app/insight_service.py
@@ -123,18 +123,51 @@ def generate_wellness_insight(history: list[dict[str, Any]], language: str) -> d
     allowed = ACTIONS.get(language, ACTIONS["English"])
     prompt = {
         "task": (
-            "Choose exactly one allowed action and return its zero-based action_index. "
-            "Write one short encouraging sentence in the requested language. Do not "
-            "diagnose, infer cognitive decline, claim causation, or add medical advice."
+            "Choose exactly one allowed action that is most useful for the repeated "
+            "longitudinal pattern. Return its zero-based action_index and one short, "
+            "plain-language encouragement sentence in the requested language."
         ),
         "anonymous_kina_scores": payload,
         "allowed_actions": allowed,
-        "response_schema": {"action_index": 0, "encouragement": "short sentence"},
     }
     try:
         response = OpenAI().responses.create(
             model=OPENAI_INSIGHT_MODEL,
+            instructions=(
+                "You write general cognitive-wellness habit information for KinaBot. "
+                "Use only the supplied anonymous sample-score history and choose only "
+                "from the supplied action list. Never diagnose, infer cognitive decline, "
+                "claim that a habit will repair a score, claim causation, recommend "
+                "medical treatment, or introduce a new action. State the useful action "
+                "directly without filler."
+            ),
             input=json.dumps(prompt, ensure_ascii=False),
+            reasoning={"effort": "low"},
+            text={
+                "verbosity": "low",
+                "format": {
+                    "type": "json_schema",
+                    "name": "kinabot_wellness_insight",
+                    "strict": True,
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "action_index": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": len(allowed) - 1,
+                            },
+                            "encouragement": {
+                                "type": "string",
+                                "maxLength": 300,
+                            },
+                        },
+                        "required": ["action_index", "encouragement"],
+                        "additionalProperties": False,
+                    },
+                },
+            },
+            store=False,
         )
         parsed = json.loads(response.output_text)
         index = max(0, min(len(allowed) - 1, int(parsed.get("action_index", 0))))

--- a/aoi_kinabot_app/local_time.py
+++ b/aoi_kinabot_app/local_time.py
@@ -1,0 +1,30 @@
+"""User-local calendar helpers while retaining UTC event timestamps."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+
+def safe_zone(timezone_name: str | None):
+    try:
+        return ZoneInfo(timezone_name or "UTC")
+    except (ZoneInfoNotFoundError, ValueError, TypeError):
+        return timezone.utc
+
+
+def local_date_iso(
+    timezone_name: str | None,
+    now_utc: datetime | None = None,
+) -> str:
+    current = now_utc or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    return current.astimezone(safe_zone(timezone_name)).date().isoformat()
+
+
+def utc_iso_to_local_date(created_at: str, timezone_name: str | None) -> str:
+    timestamp = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(safe_zone(timezone_name)).date().isoformat()

--- a/aoi_kinabot_app/reflection_profile.py
+++ b/aoi_kinabot_app/reflection_profile.py
@@ -1,0 +1,107 @@
+"""Friendly, local-only presentation of KinaBot sample feature scores."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+PROFILE_COMPONENTS = {
+    "Expression": ("Vocabulary Variety", "Response Length", "Sentence Complexity"),
+    "Flow": ("Speech Pace", "Pause Pattern", "Repetition Pattern"),
+    "Clarity": ("Transcription Clarity", "Sentence Complexity"),
+    "Energy": ("Response Length", "Speech Pace", "Emotional Tone"),
+}
+
+COPY = {
+    "English": {
+        "title": "Your expression snapshot",
+        "subtitle": "A simple view of this recording—not a health or personality rating.",
+        "labels": {
+            "Expression": "Expression",
+            "Flow": "Flow",
+            "Clarity": "Clarity",
+            "Energy": "Vocal energy",
+        },
+        "takeaway": "Core takeaway",
+        "summary": "Your clearest feature in this sample was {strong}. A useful area to explore next is {focus}.",
+        "actions": {
+            "Expression": "Tomorrow, tell a short story using one person, one place, and one feeling.",
+            "Flow": "Tomorrow, speak for one minute and allow a comfortable pause between ideas.",
+            "Clarity": "Tomorrow, record in a quiet place and speak one complete thought at a time.",
+            "Energy": "Tomorrow, describe one enjoyable moment for one minute in your natural voice.",
+        },
+        "action_title": "Try tomorrow",
+        "detail": "View the 8 measured features",
+    },
+    "日本語": {
+        "title": "今回の表現スナップショット",
+        "subtitle": "今回の録音をわかりやすく示したもので、健康や性格の評価ではありません。",
+        "labels": {
+            "Expression": "表現",
+            "Flow": "流れ",
+            "Clarity": "明瞭さ",
+            "Energy": "声のエネルギー",
+        },
+        "takeaway": "今回のポイント",
+        "summary": "今回もっとも明確だった特徴は「{strong}」です。次は「{focus}」も試してみましょう。",
+        "actions": {
+            "Expression": "明日は、人物・場所・気持ちを一つずつ入れて短い話をしてみましょう。",
+            "Flow": "明日は1分間、考えの間に自然な間を取りながら話してみましょう。",
+            "Clarity": "明日は静かな場所で、一つの考えを一文ずつ話してみましょう。",
+            "Energy": "明日は楽しかった出来事を一つ、自然な声で1分間話してみましょう。",
+        },
+        "action_title": "明日やってみること",
+        "detail": "8つの測定特徴を見る",
+    },
+    "中文": {
+        "title": "本次表达画像",
+        "subtitle": "这是本次录音的简明展示，不是健康或性格评价。",
+        "labels": {
+            "Expression": "表达",
+            "Flow": "流畅",
+            "Clarity": "清晰",
+            "Energy": "声音活力",
+        },
+        "takeaway": "核心特点",
+        "summary": "本次最明显的特点是“{strong}”；下次可以重点体验“{focus}”。",
+        "actions": {
+            "Expression": "明天讲一个小故事，加入一个人物、一个地点和一种感受。",
+            "Flow": "明天连续说一分钟，每个想法之间留一个自然停顿。",
+            "Clarity": "明天在安静环境中录音，每次完整表达一个想法。",
+            "Energy": "明天用自然的声音讲一分钟令你开心的小事。",
+        },
+        "action_title": "明天试一试",
+        "detail": "查看 8 项测量特征",
+    },
+}
+
+
+def build_reflection_profile(scores: list[dict[str, Any]], language: str) -> dict:
+    """Aggregate existing local features into four transparent UX dimensions."""
+    values = {str(item["feature_name"]): float(item["score"]) for item in scores}
+    dimensions = {
+        name: round(
+            sum(values.get(feature, 0.0) for feature in features) / len(features)
+        )
+        for name, features in PROFILE_COMPONENTS.items()
+    }
+    copy = COPY.get(language, COPY["English"])
+    strongest = max(dimensions, key=dimensions.get)
+    focus = min(dimensions, key=dimensions.get)
+    labels = copy["labels"]
+    return {
+        "title": copy["title"],
+        "subtitle": copy["subtitle"],
+        "dimensions": [
+            {"key": key, "label": labels[key], "score": dimensions[key]}
+            for key in PROFILE_COMPONENTS
+        ],
+        "takeaway_title": copy["takeaway"],
+        "takeaway": copy["summary"].format(
+            strong=labels[strongest],
+            focus=labels[focus],
+        ),
+        "action_title": copy["action_title"],
+        "action": copy["actions"][focus],
+        "detail_label": copy["detail"],
+    }

--- a/aoi_kinabot_app/requirements.txt
+++ b/aoi_kinabot_app/requirements.txt
@@ -1,4 +1,4 @@
-streamlit>=1.32.0
+streamlit>=1.40.0
 pandas>=2.0.0
 openai>=1.0.0
 faster-whisper>=1.1.0

--- a/aoi_kinabot_app/requirements.txt
+++ b/aoi_kinabot_app/requirements.txt
@@ -4,3 +4,4 @@ openai>=1.0.0
 faster-whisper>=1.1.0
 jieba>=0.42.1
 janome>=0.5.0
+tzdata>=2026.1

--- a/aoi_kinabot_app/test_multilingual.py
+++ b/aoi_kinabot_app/test_multilingual.py
@@ -60,7 +60,7 @@ def test_saved_profile_is_restored_for_returning_user(tmp_path: Path, monkeypatc
     monkeypatch.setattr(database, "DATABASE_PATH", tmp_path / "kina.sqlite3")
     database.init_db()
     user_id = database.upsert_user("returning-user", "person@example.com")
-    database.update_user_profile(user_id, "Kina", "45-59", "Chinese", "US")
+    database.update_user_profile(user_id, "Kina", "45-59", "Woman", "Chinese", "US")
 
     same_user_id = database.upsert_user("returning-user", "person@example.com")
     profile = database.get_user_profile(same_user_id)
@@ -68,6 +68,7 @@ def test_saved_profile_is_restored_for_returning_user(tmp_path: Path, monkeypatc
     assert same_user_id == user_id
     assert profile["display_name"] == "Kina"
     assert profile["age_range"] == "45-59"
+    assert profile["gender"] == "Woman"
     assert profile["primary_language"] == "Chinese"
     assert profile["country_region"] == "US"
 

--- a/aoi_kinabot_app/test_multilingual.py
+++ b/aoi_kinabot_app/test_multilingual.py
@@ -1,7 +1,9 @@
 from pathlib import Path
+from datetime import datetime, timezone
 
 import database
 from language_analysis import LANGUAGE_CODES, analyze_transcript
+from local_time import local_date_iso
 from reflection_profile import build_reflection_profile
 from insight_service import anonymous_trend_payload, generate_wellness_insight
 from scoring import calculate_feature_scores, display_feature_name, tokenize
@@ -188,3 +190,35 @@ def test_research_export_excludes_direct_identifiers(tmp_path: Path, monkeypatch
     assert row["participant_id"] == "P000001"
     assert "email" not in row
     assert "display_name" not in row
+
+
+def test_daily_limit_uses_browser_local_midnight(tmp_path: Path, monkeypatch):
+    assert local_date_iso(
+        "America/New_York",
+        datetime(2026, 7, 29, 0, 30, tzinfo=timezone.utc),
+    ) == "2026-07-28"
+
+    monkeypatch.setattr(database, "DATABASE_PATH", tmp_path / "kina.sqlite3")
+    database.init_db()
+    user_id = database.upsert_user("timezone-user", "timezone@example.com")
+    session_id = database.create_test_session(
+        user_id=user_id,
+        session_date="2026-07-29",
+        session_number=1,
+        app_version="test",
+        consent_version="test",
+        scoring_model_version="test",
+    )
+    with database.get_connection() as conn:
+        conn.execute(
+            "UPDATE test_sessions SET created_at = ? WHERE id = ?",
+            ("2026-07-29T00:30:00+00:00", session_id),
+        )
+
+    migrated = database.assign_timezone_to_legacy_sessions(
+        user_id,
+        "America/New_York",
+    )
+    assert migrated == 1
+    assert database.count_tests_today(user_id, "2026-07-28") == 1
+    assert database.count_tests_today(user_id, "2026-07-29") == 0

--- a/aoi_kinabot_app/test_multilingual.py
+++ b/aoi_kinabot_app/test_multilingual.py
@@ -56,6 +56,22 @@ def test_habit_checkins_are_upserted(tmp_path: Path, monkeypatch):
     assert values == {"physical_activity": 1, "social_connection": 0}
 
 
+def test_saved_profile_is_restored_for_returning_user(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(database, "DATABASE_PATH", tmp_path / "kina.sqlite3")
+    database.init_db()
+    user_id = database.upsert_user("returning-user", "person@example.com")
+    database.update_user_profile(user_id, "Kina", "45-59", "Chinese", "US")
+
+    same_user_id = database.upsert_user("returning-user", "person@example.com")
+    profile = database.get_user_profile(same_user_id)
+
+    assert same_user_id == user_id
+    assert profile["display_name"] == "Kina"
+    assert profile["age_range"] == "45-59"
+    assert profile["primary_language"] == "Chinese"
+    assert profile["country_region"] == "US"
+
+
 def test_calculate_feature_scores_accepts_language():
     scores = calculate_feature_scores("今日は友人と話しました。", 20, "日本語")
     assert len(scores) == 8

--- a/aoi_kinabot_app/test_multilingual.py
+++ b/aoi_kinabot_app/test_multilingual.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import database
 from language_analysis import LANGUAGE_CODES, analyze_transcript
+from reflection_profile import build_reflection_profile
 from insight_service import anonymous_trend_payload, generate_wellness_insight
 from scoring import calculate_feature_scores, display_feature_name, tokenize
 from speech_to_text import calculate_pause_metrics
@@ -28,6 +29,28 @@ def test_local_nlp_scores_multilingual():
         assert len(scores) == 8
         assert all(0 <= item["score"] <= 100 for item in scores)
         assert summary
+
+
+def test_first_session_snapshot_is_local_and_language_matched():
+    scores = [
+        {"feature_name": name, "score": 70}
+        for name in [
+            "Vocabulary Variety",
+            "Response Length",
+            "Sentence Complexity",
+            "Speech Pace",
+            "Pause Pattern",
+            "Repetition Pattern",
+            "Emotional Tone",
+            "Transcription Clarity",
+        ]
+    ]
+    for language in ["English", "日本語", "中文"]:
+        snapshot = build_reflection_profile(scores, language)
+        assert len(snapshot["dimensions"]) == 4
+        assert all(item["score"] == 70 for item in snapshot["dimensions"])
+        assert snapshot["takeaway"]
+        assert snapshot["action"]
 
 
 def test_wellness_menu_is_not_selected_from_scores():


### PR DESCRIPTION
﻿## What changed

- remembers returning-user profiles and adds private demographic summaries
- requires one clear daily wellness-habit selection
- connects anonymous longitudinal scores to bounded wellness insights
- increases the daily limit to three reflections
- adds direct in-page recording plus upload fallback
- adds a first-session four-dimension expression snapshot and practical next action
- adds CloudFront HTTPS for mobile microphone access
- fixes daily limits to use each browser's local timezone and corrects legacy UTC-dated sessions

## Why

These changes reduce mobile friction, make the first result useful, preserve longitudinal research data, and ensure daily limits reset at the user's local midnight.

## Validation

- Docker image builds successfully
- Python syntax checks pass
- three-language expression snapshot test passes
- returning-profile persistence test passes
- local-midnight and legacy-session migration test passes
- AWS ECS rollout is deployed from the branch image
