### PR TITLE
Add the KinaBot open knowledge center

### DIFF
--- a/aoi_kinabot_app/CHANGELOG.md
+++ b/aoi_kinabot_app/CHANGELOG.md
@@ -38,6 +38,8 @@ changelog.
   snapshot available from the first completed reflection.
 - Browser-timezone daily limits with UTC timestamps, local session dates, and
   one-time correction of legacy UTC-dated sessions.
+- A public `docs/` knowledge center covering product and UX learnings,
+  engineering lessons, responsible wellness design, and key decisions.
 
 ### Changed
 

--- a/aoi_kinabot_app/README.md
+++ b/aoi_kinabot_app/README.md
@@ -58,6 +58,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) and
 
 Project records:
 
+- [Open knowledge center](docs/README.md)
 - [Changelog](CHANGELOG.md)
 - [Verifiable impact](IMPACT.md)
 - [Founder and maintainership](OWNERSHIP-AND-MAINTAINERSHIP.md)

--- a/aoi_kinabot_app/docs/DECISION-LOG.md
+++ b/aoi_kinabot_app/docs/DECISION-LOG.md
@@ -1,0 +1,32 @@
+# KinaBot Decision Log
+
+This log records important product and engineering decisions. Dates describe
+when the decision was documented, not necessarily the first time an idea was
+considered.
+
+| Date | Decision | Reason |
+|---|---|---|
+| 2026-07-28 | Keep feature scoring in local Python/NLP | Reproducibility, privacy, and clear ownership of the core method |
+| 2026-07-28 | Support English, Japanese, and Chinese with language-specific adapters | A global tool cannot treat English rules as universal |
+| 2026-07-28 | Do not retain raw audio or full transcripts | Reduce sensitivity and align retention with the product's actual need |
+| 2026-07-28 | Limit the LLM to anonymous score trends and curated actions | Prevent the LLM from becoming the scoring or diagnostic authority |
+| 2026-07-29 | Allow three reflections per local day | Let users see an early trend while limiting repetitive testing and cost |
+| 2026-07-29 | Restore returning-user profiles by verified email | Remove repeated onboarding burden |
+| 2026-07-29 | Require one daily habit selection | Make self-reported habit data easier to understand |
+| 2026-07-29 | Add direct browser recording with upload fallback | Reduce mobile friction without removing accessibility options |
+| 2026-07-29 | Add a four-dimension first-session expression snapshot | Give an understandable result before longitudinal trends exist |
+| 2026-07-29 | Use CloudFront HTTPS | Enable secure mobile microphone access with a stable AWS endpoint |
+| 2026-07-29 | Store UTC timestamps plus browser-local dates and IANA timezone | Reset limits at the user's expected midnight and preserve auditability |
+| 2026-07-30 | Establish a public knowledge center | Share verified product and engineering lessons while protecting users and invention-sensitive details |
+
+## Template for Future Decisions
+
+Add a row above and, when more detail is useful, include:
+
+- problem observed;
+- alternatives considered;
+- decision;
+- evidence;
+- risks;
+- validation needed; and
+- version or pull request that implemented the change.

--- a/aoi_kinabot_app/docs/ENGINEERING-LEARNINGS.md
+++ b/aoi_kinabot_app/docs/ENGINEERING-LEARNINGS.md
@@ -1,0 +1,112 @@
+# Engineering Learnings
+
+## 1. Separate Scoring from Explanation
+
+KinaBot's versioned Python/NLP pipeline calculates the features. An optional LLM
+may turn anonymous longitudinal score patterns and a curated action library into
+plain language, but it is not the scoring authority.
+
+This separation improves reproducibility, cost control, failure handling, and
+privacy.
+
+## 2. Design a Safe Fallback
+
+External APIs can fail because of credentials, quota, model access, TLS
+inspection, or network problems. KinaBot falls back to a deterministic,
+research-linked action library so a user still receives a result.
+
+The next operational improvement is explicit, privacy-safe observability that
+distinguishes an AI-selected action from a fallback without logging sensitive
+payloads.
+
+## 3. Treat Audio as Ephemeral
+
+The server needs a temporary copy to transcribe uploaded or browser-recorded
+audio. The copy must be deleted on success and error paths. Raw audio and full
+transcripts are not retained and are not sent to the LLM.
+
+Persistent records contain account data, consent, session metadata, raw feature
+metrics, scores, and scoring versions.
+
+## 4. HTTPS Is a Product Requirement
+
+Mobile browser microphone access requires a secure context. An HTTP load
+balancer URL may serve a page successfully while the recording feature still
+fails.
+
+The pilot uses:
+
+```text
+Mobile or desktop browser
+  -> CloudFront HTTPS
+  -> Application Load Balancer
+  -> ECS Fargate
+  -> encrypted EFS-backed SQLite
+```
+
+CloudFront caching is disabled for the dynamic Streamlit application, and
+viewer requests are forwarded to preserve sessions and interactive behavior.
+
+## 5. Store UTC and Local-Time Meaning
+
+UTC alone is insufficient for a daily-use product. KinaBot stores:
+
+- `created_at`: timezone-aware UTC timestamp;
+- `session_date`: browser-local calendar date; and
+- `timezone_name`: IANA timezone used for that date.
+
+Legacy sessions without a timezone are corrected once when the user returns.
+New sessions retain their original timezone even if the user later travels.
+
+## 6. Make Database Migrations Additive
+
+The pilot database is persistent. New profile and timezone fields are added with
+idempotent migrations rather than replacing the database. Deployment must never
+erase EFS data.
+
+SQLite is appropriate for a single-task pilot. Before horizontal scaling or
+material concurrent use, migrate transactional data to a managed relational
+database such as PostgreSQL.
+
+## 7. Version Research-Relevant Behavior
+
+Each result should retain:
+
+- application version;
+- scoring-model version;
+- consent version;
+- spoken language;
+- session timestamp and local date;
+- raw feature metrics; and
+- displayed feature scores.
+
+Without versioning, longitudinal comparisons become difficult to interpret
+after an algorithm change.
+
+## 8. Keep Identities Separate from Research Exports
+
+The private user export contains direct identifiers and must be access
+restricted. The research export uses a participant ID and excludes email,
+display name, recordings, and transcripts.
+
+De-identification alone does not create research consent or remove governance
+responsibilities.
+
+## 9. Test the Real Runtime
+
+Local syntax checks are necessary but insufficient. Validate:
+
+- the Docker image;
+- database migration on persistent data;
+- ECS service stability;
+- HTTPS response;
+- mobile microphone permission;
+- three-language output;
+- local-midnight behavior; and
+- safe behavior when external services are unavailable.
+
+## 10. Never Put Secrets in Git
+
+API credentials belong in AWS Secrets Manager or local environment variables.
+Logs and diagnostic commands should be designed so exceptions cannot echo a
+secret. If a key appears in terminal output, revoke and rotate it.

--- a/aoi_kinabot_app/docs/PRODUCT-UX-LEARNINGS.md
+++ b/aoi_kinabot_app/docs/PRODUCT-UX-LEARNINGS.md
@@ -1,0 +1,110 @@
+# Product and UX Learnings
+
+## Product Goal
+
+KinaBot should let an ordinary person complete a short voice reflection with
+minimal instruction, receive an understandable result immediately, and return
+over time without feeling tested or judged.
+
+## 1. Record in the Page
+
+**Observed problem:** Asking mobile users to record in another app, locate the
+file, and upload it creates avoidable drop-off. Some iPhone users do not know
+where a recording was saved.
+
+**Design response:** Make browser recording the primary path:
+
+1. choose the spoken language;
+2. choose **Record now** or **Upload a recording**; and
+3. select **Analyze my reflection**.
+
+Upload remains available for accessibility, testing, and previously recorded
+audio. Browser recording requires HTTPS and a clear microphone-permission
+prompt.
+
+## 2. Give Value on the First Session
+
+**Observed problem:** Eight technical feature scores and a disclaimer can feel
+like work without a useful outcome.
+
+**Design response:** Present a friendly first-session expression snapshot:
+
+- Expression;
+- Flow;
+- Clarity; and
+- Vocal energy.
+
+These four dimensions are transparent presentations of existing local features,
+not new medical or personality measurements. The detailed eight-feature view
+remains available in an expandable section.
+
+Every completed reflection should provide:
+
+- one core takeaway;
+- one small action to try tomorrow; and
+- a clear explanation that trends unlock after repeated sessions.
+
+## 3. Avoid Entertainment Metrics That Pretend to Be Science
+
+“Luck,” “fortune,” intelligence, cognitive age, and disease risk may attract
+attention but cannot be responsibly inferred from a short recording.
+
+Friendly design is encouraged. Unsupported interpretation is not. Emotional
+wording may describe language used in a sample, but it must not claim to know a
+person's internal emotional state.
+
+## 4. Remember Returning Users
+
+**Observed problem:** Re-entering name and profile information makes the app
+feel forgetful and increases burden.
+
+**Design response:** Use the verified email as the account key. Collect the
+required pilot profile once, store it privately, restore it on later visits, and
+greet the returning user by name. Keep account settings available but collapsed.
+
+## 5. Use the User's Local Calendar Day
+
+**Observed problem:** A server running in UTC can count an evening U.S. session
+as the next day.
+
+**Design response:** Keep the precise event timestamp in UTC, but calculate the
+daily usage date from the browser's IANA timezone. Reset the three-session
+allowance at the user's local midnight.
+
+This is easier to understand than a rolling 24-hour window and preserves an
+auditable explanation of how each session date was assigned.
+
+## 6. Make Habit Check-ins Unambiguous
+
+Independent checkboxes made it unclear whether zero, one, or several habits
+were expected.
+
+The pilot now asks the user to select one self-reported wellness habit for the
+day. Habit records stay separate from speech scores, and KinaBot does not claim
+that a habit caused a score change.
+
+## 7. Match the User's Language
+
+Interface labels, explanations, takeaways, and actions should match the language
+selected for the recording. Multilingual support is not word-for-word
+translation: segmentation, pace units, grammar cues, examples, and validation
+must be language appropriate.
+
+## 8. Reduce Words, Not Transparency
+
+The main path should be short and calm. Privacy, scoring details, and boundaries
+should remain available through concise cards and expandable detail sections.
+Critical consent must never be hidden.
+
+## Pilot Questions to Measure
+
+- Can a new mobile user finish without help?
+- How long does the first reflection take?
+- Does the first result feel useful?
+- Does the user understand that scores describe one sample?
+- Does the user return within seven days?
+- Where do users abandon the flow?
+- Do English, Japanese, and Chinese users interpret the labels similarly?
+
+Record measured answers in `IMPACT.md`; do not replace evidence with promotional
+claims.

--- a/aoi_kinabot_app/docs/README.md
+++ b/aoi_kinabot_app/docs/README.md
@@ -1,0 +1,53 @@
+# KinaBot Open Knowledge Center
+
+KinaBot is both a working open-source application and a learning project for
+building accessible, privacy-conscious speech reflection tools.
+
+This knowledge center records what the project has learned from product design,
+user feedback, multilingual NLP, privacy engineering, and AWS operations. The
+goal is to help people build useful wellness technology without overstating
+what a voice sample can prove.
+
+## Start Here
+
+- [Product and UX Learnings](PRODUCT-UX-LEARNINGS.md)
+- [Engineering Learnings](ENGINEERING-LEARNINGS.md)
+- [Responsible Wellness Design](RESPONSIBLE-WELLNESS-DESIGN.md)
+- [Decision Log](DECISION-LOG.md)
+
+Technical references remain in the application root:
+
+- [Architecture](../ARCHITECTURE.md)
+- [Scoring Methodology](../SCORING-METHODOLOGY.md)
+- [Data and Access Design](../data-and-access-design.md)
+- [Verifiable Impact](../IMPACT.md)
+- [Changelog](../CHANGELOG.md)
+
+## What Is Public
+
+KinaBot openly shares:
+
+- product and accessibility lessons;
+- system architecture and privacy boundaries;
+- observable feature definitions;
+- validation expectations;
+- non-medical communication principles; and
+- operational lessons that can help other builders.
+
+KinaBot does not publish:
+
+- user identity or production research exports;
+- API keys, credentials, or private infrastructure access;
+- raw recordings or full transcripts;
+- claims that have not been validated;
+- confidential partner information; or
+- potentially patent-sensitive implementation details that have not been
+  cleared for public disclosure.
+
+## How to Use These Documents
+
+Treat each lesson as a versioned design record, not universal truth. A lesson
+should identify the observed problem, the design response, the reason for the
+response, and the evidence still needed.
+
+This documentation is educational. It is not medical, legal, or patent advice.

--- a/aoi_kinabot_app/docs/RESPONSIBLE-WELLNESS-DESIGN.md
+++ b/aoi_kinabot_app/docs/RESPONSIBLE-WELLNESS-DESIGN.md
@@ -1,0 +1,97 @@
+# Responsible Wellness Design
+
+## Scope
+
+KinaBot is a personal speech-reflection and cognitive-wellness habit tool. It is
+not a medical device and does not diagnose, screen for disease, estimate risk,
+or recommend treatment.
+
+## Claims the Product Can Make
+
+KinaBot may describe observable properties of one recording:
+
+- vocabulary variety;
+- amount and structure of speech;
+- pace and pause behavior;
+- repetition;
+- wording patterns; and
+- transcription clarity.
+
+After repeated sessions, it may describe whether the user's own samples appear
+higher, lower, or similar on those versioned features.
+
+## Claims the Product Must Not Make
+
+KinaBot must not convert a feature or trend into:
+
+- cognitive decline;
+- dementia or another diagnosis;
+- intelligence or cognitive age;
+- a medical risk score;
+- proof of improvement;
+- proof that a habit caused a change; or
+- certainty about a person's internal emotion.
+
+## Wellness Actions
+
+An action should be:
+
+- small enough to do in daily life;
+- stated in the user's language;
+- specific about time or duration;
+- selected from a curated action library;
+- connected to a public research source; and
+- framed as general wellness information.
+
+A research source may support a habit in general. It does not prove that the
+habit will change an individual's KinaBot score.
+
+## Human-Centered Communication
+
+Use direct language without filler. Avoid red warning-heavy interfaces unless
+there is an actual error. Explain uncertainty near the relevant result.
+
+Encourage a person with persistent concerns to consult a qualified professional,
+without implying that KinaBot detected a condition.
+
+## Data Dignity
+
+Users should know:
+
+- what is stored;
+- what is deleted;
+- what may be sent to an external service;
+- why the data is needed;
+- how long it is retained; and
+- how to request access or deletion.
+
+Research use requires an appropriate protocol, consent, governance,
+de-identification, and ethics review where applicable. Product consent is not
+automatically research consent.
+
+## Accessibility and Inclusion
+
+The product should be usable by older adults and people with limited technical
+experience. Priorities include:
+
+- large, clear actions;
+- direct browser recording;
+- an upload alternative;
+- low reading burden;
+- sufficient contrast;
+- keyboard and screen-reader compatibility;
+- plain explanations; and
+- language-appropriate testing with fluent speakers.
+
+Scores should not be interpreted across languages or demographic groups as if
+they were automatically equivalent.
+
+## Open Source and Invention Boundaries
+
+Open source can increase trust, reproducibility, public benefit, and independent
+review. Public documentation should still exclude personal data, credentials,
+confidential relationships, and patent-sensitive implementation details that
+have not been cleared for disclosure.
+
+This repository is educational and technical documentation, not legal or
+medical advice.


### PR DESCRIPTION
﻿## What changed

- adds a public KinaBot open knowledge center under `aoi_kinabot_app/docs/`
- records product and UX lessons from real user feedback
- records privacy, AWS, timezone, data, and reliability engineering lessons
- documents responsible non-medical wellness design boundaries
- adds a dated decision log and public/private disclosure boundary
- links the knowledge center from the application README and changelog

## Why

KinaBot should share not only source code, but also reusable knowledge about building accessible, privacy-conscious speech reflection tools. The documentation deliberately excludes user data, credentials, unsupported claims, and uncleared patent-sensitive details.

## Validation

- Markdown links verified locally
- `git diff --check` passed
- documentation-only change; no production runtime behavior changed
