### PR TITLE
Add mobile trends and open feedback learning record

### DIFF
--- a/aoi_kinabot_app/CHANGELOG.md
+++ b/aoi_kinabot_app/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-08-02 · Mobile results and open learning record
+
+- Added a compact two-column eight-feature result grid for narrow screens.
+- Added top-level Today and Trends navigation after sign-in.
+- Added latest-result recall and one-feature-at-a-time recent/all trend views.
+- Added in-app scoring transparency linked to the versioned methodology.
+- Published anonymized feedback, mobile UX, metric-definition, and university
+  teaching-case documentation.
+
 ## 2026-07-31 · Multilingual landing experience
 
 - Added a warm, minimal first screen built around the brand line

--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import date
-
 import pandas as pd
 import streamlit as st
 
@@ -37,6 +36,7 @@ from database import (
     upsert_user,
 )
 from email_delivery import send_verification_email
+from history_view import latest_session_scores, metric_grid_html
 from insight_service import generate_wellness_insight
 from language_analysis import LANGUAGE_CODES, analyze_transcript
 from local_time import local_date_iso
@@ -45,7 +45,7 @@ from speech_to_text import (
     speech_to_text_configured,
     transcribe_audio_upload,
 )
-from scoring import display_feature_name
+from scoring import display_feature_name, feature_explanation
 from reflection_profile import build_reflection_profile
 from wellness_guidance import wellness_suggestions
 
@@ -147,6 +147,55 @@ st.markdown(
     .snapshot-card__fill {
         height: 100%; background: linear-gradient(90deg, #f28a5c, #e55438);
         border-radius: 99px;
+    }
+    .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.65rem;
+        margin: 0.75rem 0 1rem;
+    }
+    .metric-tile {
+        min-width: 0;
+        padding: 0.78rem 0.82rem;
+        border: 1px solid rgba(49, 51, 63, 0.12);
+        border-radius: 0.9rem;
+        background: linear-gradient(145deg, #fffaf7, #ffffff);
+    }
+    .metric-tile__top {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 0.55rem;
+    }
+    .metric-tile__name {
+        color: #343741;
+        font-size: 0.83rem;
+        font-weight: 680;
+        line-height: 1.25;
+    }
+    .metric-tile__value {
+        color: #e65f3c;
+        font-size: 1.05rem;
+        font-weight: 800;
+        line-height: 1;
+        white-space: nowrap;
+    }
+    .metric-tile__track {
+        height: 0.3rem;
+        margin-top: 0.65rem;
+        overflow: hidden;
+        border-radius: 99px;
+        background: #f5e4dc;
+    }
+    .metric-tile__fill {
+        height: 100%;
+        border-radius: 99px;
+        background: linear-gradient(90deg, #f28a5c, #e55438);
+    }
+    @media (max-width: 430px) {
+        .block-container {padding-left: 1rem; padding-right: 1rem;}
+        .metric-grid {gap: 0.5rem;}
+        .metric-tile {padding: 0.7rem;}
     }
     </style>
     """,
@@ -251,6 +300,77 @@ AUDIO_CAPTURE_COPY = {
         "fallback": "无法使用麦克风？请改选上传已有录音。",
     },
 }
+
+HISTORY_COPY = {
+    "English": {
+        "today": "Today",
+        "trends": "Trends",
+        "latest": "Latest 8-feature snapshot",
+        "no_scores": "No saved scores yet.",
+        "progress": "{count} of 3 sessions completed. Trends begin after session 3.",
+        "recent": "Recent sessions",
+        "all": "All sessions",
+        "change": "Observed change since the first sample",
+        "higher": "Higher in latest sample",
+        "lower": "Lower in latest sample",
+        "similar": "Similar",
+        "method": "How the 8 features are calculated",
+        "method_intro": (
+            "KinaBot calculates descriptive 0–100 feature indexes with its own "
+            "Python and multilingual NLP pipeline. They are not percentages, "
+            "population rankings, or health scores."
+        ),
+        "boundary": (
+            "These are descriptive sample-to-sample differences only. KinaBot does "
+            "not infer health, improvement, decline, cause, or risk."
+        ),
+    },
+    "日本語": {
+        "today": "今日",
+        "trends": "トレンド",
+        "latest": "最新の8項目",
+        "no_scores": "保存されたスコアはまだありません。",
+        "progress": "3回中{count}回完了しました。3回目からトレンドを表示します。",
+        "recent": "最近のセッション",
+        "all": "すべてのセッション",
+        "change": "最初のサンプルからの変化",
+        "higher": "最新サンプルで高い",
+        "lower": "最新サンプルで低い",
+        "similar": "ほぼ同じ",
+        "method": "8項目の計算方法",
+        "method_intro": (
+            "KinaBot独自のPythonと多言語NLPにより、0〜100の記述的な特徴指数を"
+            "計算します。割合、集団順位、健康スコアではありません。"
+        ),
+        "boundary": (
+            "サンプル間の記述的な差だけを示します。健康、改善、低下、原因、"
+            "リスクを推定するものではありません。"
+        ),
+    },
+    "中文": {
+        "today": "今天",
+        "trends": "趋势",
+        "latest": "最近一次的8项指标",
+        "no_scores": "目前还没有保存的分数。",
+        "progress": "已完成3次中的{count}次，第3次开始显示趋势。",
+        "recent": "最近记录",
+        "all": "全部记录",
+        "change": "与第一次样本相比的变化",
+        "higher": "最近一次较高",
+        "lower": "最近一次较低",
+        "similar": "基本相近",
+        "method": "8项指标如何计算",
+        "method_intro": (
+            "KinaBot使用自己的Python与多语言NLP流程计算0–100的描述性特征指数。"
+            "它们不是百分比、人群排名或健康评分。"
+        ),
+        "boundary": (
+            "这里只描述不同语音样本之间的差异。KinaBot不推断健康、改善、下降、"
+            "原因或风险。"
+        ),
+    },
+}
+
 
 if "ui_language" not in st.session_state:
     st.session_state.ui_language = "English"
@@ -506,6 +626,117 @@ if not profile_complete:
     st.info("Complete your account once. KinaBot will remember it for future visits.")
     st.stop()
 
+history_copy = HISTORY_COPY[st.session_state.ui_language]
+primary_view = st.radio(
+    "KinaBot navigation",
+    ["today", "trends"],
+    format_func=lambda option: history_copy[option],
+    horizontal=True,
+    label_visibility="collapsed",
+    key="primary_view",
+)
+
+if primary_view == "trends":
+    assign_timezone_to_legacy_sessions(st.session_state.user_id, browser_timezone)
+    rows = get_user_scores(st.session_state.user_id)
+    st.subheader(history_copy["trends"])
+    if not rows:
+        st.caption(history_copy["no_scores"])
+        st.stop()
+
+    history = pd.DataFrame([dict(row) for row in rows])
+    session_count = int(history["session_id"].nunique())
+    st.markdown(f"### {history_copy['latest']}")
+    st.markdown(
+        metric_grid_html(
+            latest_session_scores(history),
+            st.session_state.ui_language,
+        ),
+        unsafe_allow_html=True,
+    )
+
+    with st.expander(history_copy["method"]):
+        st.write(history_copy["method_intro"])
+        for feature_name in history["feature_name"].drop_duplicates():
+            label = display_feature_name(feature_name, st.session_state.ui_language)
+            explanation = feature_explanation(
+                feature_name, st.session_state.ui_language
+            )
+            st.markdown(f"**{label}** — {explanation}")
+        st.link_button(
+            "Open scoring methodology",
+            "https://github.com/usekina/kina/blob/main/aoi_kinabot_app/SCORING-METHODOLOGY.md",
+            use_container_width=True,
+        )
+
+    if session_count < 3:
+        st.info(history_copy["progress"].format(count=session_count))
+        st.stop()
+
+    feature_names = list(history["feature_name"].drop_duplicates())
+    selected_feature = st.selectbox(
+        history_copy["recent"],
+        feature_names,
+        format_func=lambda name: display_feature_name(
+            name, st.session_state.ui_language
+        ),
+    )
+    history_scope = st.radio(
+        "History range",
+        ["recent", "all"],
+        format_func=lambda option: history_copy[option],
+        horizontal=True,
+        label_visibility="collapsed",
+    )
+    feature_history = history[history["feature_name"] == selected_feature].sort_values(
+        "session_id"
+    )
+    if history_scope == "recent":
+        feature_history = feature_history.tail(3)
+    feature_history = feature_history.copy()
+    feature_history["session_label"] = (
+        feature_history["session_date"].astype(str)
+        + " #"
+        + feature_history["session_number"].astype(str)
+    )
+    chart_df = feature_history[["session_label", "score"]].set_index("session_label")
+    chart_df = chart_df.rename(
+        columns={
+            "score": display_feature_name(
+                selected_feature, st.session_state.ui_language
+            )
+        }
+    )
+    st.line_chart(chart_df, height=260)
+
+    ordered = history.sort_values("session_id")
+    first_score = float(
+        ordered[ordered["feature_name"] == selected_feature].iloc[0]["score"]
+    )
+    latest_score = float(
+        ordered[ordered["feature_name"] == selected_feature].iloc[-1]["score"]
+    )
+    observed_change = latest_score - first_score
+    pattern = (
+        history_copy["higher"]
+        if observed_change > 2
+        else history_copy["lower"]
+        if observed_change < -2
+        else history_copy["similar"]
+    )
+    st.markdown(f"**{history_copy['change']}**")
+    st.write(f"{pattern} ({observed_change:+.1f})")
+    st.caption(history_copy["boundary"])
+
+    insight = generate_wellness_insight([dict(row) for row in rows], st.session_state.ui_language)
+    st.markdown("#### One small action")
+    if insight.get("encouragement"):
+        st.write(insight["encouragement"])
+    st.info(insight["action"])
+    st.caption(f"{insight['why']} [Research source]({insight['source']})")
+    st.caption(insight["boundary"])
+    st.stop()
+
 st.markdown(
     """
     <div class="privacy-card">
@@ -688,70 +919,15 @@ if st.button("3 · Analyze my reflection", type="primary", use_container_width=T
         st.markdown(f"#### {snapshot['action_title']}")
         st.info(snapshot["action"])
         st.caption(result_copy["scale"])
+        st.markdown(
+            metric_grid_html(scores, language),
+            unsafe_allow_html=True,
+        )
         with st.expander(snapshot["detail_label"]):
             for item in scores:
-                score = int(round(float(item["score"])))
                 label = display_feature_name(item["feature_name"], language)
-                st.markdown(
-                    f"""
-                    <div class="score-card">
-                      <div class="score-card__top">
-                        <span class="score-card__name">{label}</span>
-                        <span class="score-card__value">{score} / 100</span>
-                      </div>
-                      <div class="score-card__track">
-                        <div class="score-card__fill" style="width:{score}%"></div>
-                      </div>
-                      <div class="score-card__explanation">{item["explanation"]}</div>
-                    </div>
-                    """,
-                    unsafe_allow_html=True,
-                )
+                st.markdown(f"**{label}** — {item['explanation']}")
         st.caption(result_copy["boundary"])
-
-st.subheader("Your history")
-rows = get_user_scores(st.session_state.user_id)
-if not rows:
-    st.caption("No saved scores yet.")
-else:
-    history = pd.DataFrame([dict(row) for row in rows])
-    session_count = len(history[["created_at", "session_number"]].drop_duplicates())
-    if session_count < 3:
-        st.info(f"{session_count} of 3 sessions completed. Trends unlock after session 3.")
-    else:
-        chart_df = history.pivot_table(
-            index="created_at",
-            columns="feature_name",
-            values="score",
-            aggfunc="mean",
-        )
-        st.line_chart(chart_df)
-
-        ordered = history.sort_values("created_at")
-        first_scores = ordered.groupby("feature_name").first()["score"]
-        latest_scores = ordered.groupby("feature_name").last()["score"]
-        change = (latest_scores - first_scores).rename("observed_change").reset_index()
-        change["pattern"] = change["observed_change"].apply(
-            lambda value: "Higher in latest sample"
-            if value > 2
-            else ("Lower in latest sample" if value < -2 else "Similar")
-        )
-        st.markdown("#### Observed change since the first sample")
-        st.dataframe(change, width="stretch", hide_index=True)
-        st.caption(
-            "These are descriptive sample-to-sample differences only. "
-            "KinaBot does not infer health, improvement, decline, cause, or risk."
-        )
-        insight = generate_wellness_insight(
-            [dict(row) for row in rows],
-            language,
-        )
-        st.markdown("#### One small action")
-        if insight.get("encouragement"):
-            st.write(insight["encouragement"])
-        st.info(insight["action"])
-        st.caption(f"{insight['why']} [Research source]({insight['source']})")
-        st.caption(insight["boundary"])
 
 st.subheader("Today's wellness habit")
 habit_copy = wellness_suggestions(language, [])

--- a/aoi_kinabot_app/database.py
+++ b/aoi_kinabot_app/database.py
@@ -358,7 +358,9 @@ def get_user_scores(user_id: int) -> list[sqlite3.Row]:
         return conn.execute(
             """
             SELECT
+                ts.id AS session_id,
                 ts.created_at,
+                ts.session_date,
                 ts.session_number,
                 ts.session_type,
                 ts.language,

--- a/aoi_kinabot_app/docs/DECISION-LOG.md
+++ b/aoi_kinabot_app/docs/DECISION-LOG.md
@@ -18,6 +18,8 @@ considered.
 | 2026-07-29 | Use CloudFront HTTPS | Enable secure mobile microphone access with a stable AWS endpoint |
 | 2026-07-29 | Store UTC timestamps plus browser-local dates and IANA timezone | Reset limits at the user's expected midnight and preserve auditability |
 | 2026-07-30 | Establish a public knowledge center | Share verified product and engineering lessons while protecting users and invention-sensitive details |
+| 2026-08-02 | Make the latest eight features and Trends reachable from mobile navigation | Reduce portrait scrolling and let returning users revisit results without repeating an analysis |
+| 2026-08-02 | Publish anonymized feedback and scoring explanations | Make design reasoning educational and auditable without exposing participant identity or overstating evidence |
 
 ## Template for Future Decisions
 

--- a/aoi_kinabot_app/docs/PRODUCT-UX-LEARNINGS.md
+++ b/aoi_kinabot_app/docs/PRODUCT-UX-LEARNINGS.md
@@ -108,3 +108,17 @@ Critical consent must never be hidden.
 
 Record measured answers in `IMPACT.md`; do not replace evidence with promotional
 claims.
+
+## 9. Make Longitudinal Results Mobile-First
+
+**Observed problem:** A portrait user could complete one analysis but had to
+scroll extensively and could not quickly revisit the latest eight features.
+The derivation of those features was also not obvious.
+
+**Design response:** Add a top-level **Today / Trends** control, show the latest
+eight features in a compact two-column grid, display one selected feature per
+trend chart, and place plain-language methodology within the interface. Keep
+the detailed public scoring methodology versioned in the repository.
+
+Research administration remains permission-gated and separate from the
+participant flow. A dedicated responsive admin route is future work.

--- a/aoi_kinabot_app/docs/README.md
+++ b/aoi_kinabot_app/docs/README.md
@@ -14,6 +14,10 @@ what a voice sample can prove.
 - [Engineering Learnings](ENGINEERING-LEARNINGS.md)
 - [Responsible Wellness Design](RESPONSIBLE-WELLNESS-DESIGN.md)
 - [Decision Log](DECISION-LOG.md)
+- [Public User Feedback](feedback/README.md)
+- [Eight Feature Definitions](methodology/METRIC-DEFINITIONS.md)
+- [Mobile-First Results Architecture](ux/MOBILE-FIRST-RESULTS.md)
+- [Purdue Data Science Teaching Case](education/PURDUE-DATA-SCIENCE-CASE-STUDY.md)
 
 Technical references remain in the application root:
 

--- a/aoi_kinabot_app/docs/education/PURDUE-DATA-SCIENCE-CASE-STUDY.md
+++ b/aoi_kinabot_app/docs/education/PURDUE-DATA-SCIENCE-CASE-STUDY.md
@@ -1,0 +1,58 @@
+# Teaching Case: From User Feedback to a Mobile Data Product
+
+This case is designed for a university data science or startup milestone
+lecture. It uses an anonymized KinaBot product iteration to show how qualitative
+feedback becomes a testable data-product decision.
+
+## Learning Objectives
+
+Students should be able to:
+
+1. separate a user's observation from a proposed solution;
+2. translate feedback into product and data requirements;
+3. explain a derived feature without overstating scientific meaning;
+4. design a mobile longitudinal view for multivariate data;
+5. distinguish engineering validation from clinical validation;
+6. document privacy boundaries and versioned scoring decisions; and
+7. connect an issue, implementation, test, release, and measured outcome.
+
+## Case Prompt
+
+An external tester reports that a single analysis is smooth but asks how eight
+indexes are produced, wants to revisit the latest result, finds portrait-mode
+scrolling excessive, and expects caregivers or older adults to use a phone
+rather than a laptop.
+
+Student teams should propose:
+
+- a mobile information architecture;
+- a transparent explanation of the eight indexes;
+- a longitudinal visualization that avoids implying diagnosis;
+- success metrics for a usability test; and
+- a privacy-preserving feedback record.
+
+## KinaBot Design Decision
+
+KinaBot implements a compact two-column latest-result grid, a top-level Trends
+destination, a one-feature-at-a-time trend chart, recent/all history controls,
+and a versioned scoring explanation. Research administration remains
+permission-gated and outside the participant's primary flow.
+
+## Discussion Questions
+
+- Does a 0–100 scale create unintended health-score expectations?
+- When should an engineering reference center be recalibrated?
+- How many repeat sessions are needed before a trend is useful?
+- Which changes require a new scoring-model version?
+- What evidence would be needed before discussing cognitive change?
+- How should accessibility testing include older adults without stereotyping
+  them?
+
+## Evidence Discipline
+
+The public repository demonstrates chronology, reproducibility, and design
+reasoning. It does not by itself establish adoption, educational impact,
+clinical validity, or extraordinary professional impact. Course delivery,
+independent feedback, usage results, permissions, and external recognition
+should be retained separately as verifiable evidence.
+

--- a/aoi_kinabot_app/docs/feedback/2026-08-mobile-results-navigation.md
+++ b/aoi_kinabot_app/docs/feedback/2026-08-mobile-results-navigation.md
@@ -1,0 +1,63 @@
+# Mobile Results, Navigation, and Scoring Transparency
+
+Date: 2026-08-02  
+Source: Anonymized external product tester  
+Context: Smartphone in portrait orientation; completed the single-session
+analysis flow  
+Consent: Feedback is paraphrased for public documentation  
+Status: Accepted and implemented for validation
+
+## Observations
+
+- The single-session analysis flow felt smooth.
+- A user may want to understand how the eight displayed features are derived.
+- A returning user may want to revisit at least the latest eight scores.
+- The existing portrait layout required excessive vertical scrolling.
+- A compact panel or navigation structure reachable within two taps may be more
+  usable than one long page.
+- Research administration needs a mobile-appropriate presentation, but likely
+  participants, caregivers, and older adults should not need a laptop to use
+  the participant experience.
+
+## Product Interpretation
+
+The feedback identifies four distinct needs:
+
+1. scoring transparency;
+2. quick access to the latest result;
+3. mobile information density; and
+4. separation between participant and research-administration workflows.
+
+## Design Response
+
+- Add a top-level **Today / Trends** control after sign-in.
+- Show the latest eight features in a compact two-column mobile grid.
+- Let the user select one feature at a time for a readable trend chart.
+- Offer recent-three-session and all-session views.
+- Put concise feature definitions in the interface and link to the versioned
+  scoring methodology.
+- Keep Research Admin permission-gated and outside the participant's primary
+  task flow. A dedicated admin route or mobile drawer remains future work.
+
+## Responsible Boundary
+
+Scores are engineered descriptive indexes for a sample. A trend is not a
+diagnosis, cognitive assessment, or proof of improvement or decline. Topic,
+language, microphone, environment, recording length, fatigue, mood, and
+transcription quality may affect a result.
+
+## Validation Needed
+
+- Can a new mobile user find Trends without instruction?
+- Can a returning user locate the latest eight features within two taps?
+- Does the two-column grid remain readable at 320–430 pixel widths?
+- Do users understand the difference between a feature index and a health
+  score?
+- Does selecting one metric reduce chart confusion?
+- Do older adults complete the flow without a laptop or caregiver assistance?
+
+## Evidence and Links
+
+- Implementation issue: https://github.com/usekina/kina/issues/26
+- Pull request: link after creation
+- Release and measured outcomes: pending usability testing

--- a/aoi_kinabot_app/docs/feedback/2026-08-mobile-results-navigation.md
+++ b/aoi_kinabot_app/docs/feedback/2026-08-mobile-results-navigation.md
@@ -59,5 +59,5 @@ transcription quality may affect a result.
 ## Evidence and Links
 
 - Implementation issue: https://github.com/usekina/kina/issues/26
-- Pull request: link after creation
+- Pull request: https://github.com/usekina/kina/pull/27
 - Release and measured outcomes: pending usability testing

--- a/aoi_kinabot_app/docs/feedback/README.md
+++ b/aoi_kinabot_app/docs/feedback/README.md
@@ -1,0 +1,42 @@
+# Public User Feedback Records
+
+This directory records anonymized product feedback and the design decisions it
+informs. The purpose is to make KinaBot's development process useful to
+students, open-source contributors, and responsible wellness-technology
+builders.
+
+Public records must:
+
+- paraphrase feedback unless the contributor gave explicit permission to quote;
+- exclude names, email addresses, recordings, transcripts, health information,
+  and other identifying details;
+- identify the device and task context when known;
+- separate an observation from the team's interpretation;
+- link the resulting issue, pull request, test, and release when available; and
+- record unresolved risks and evidence still needed.
+
+Feedback is evidence of a product-design input. It is not proof of clinical
+validity, user impact, adoption, or causation.
+
+## Record Template
+
+```markdown
+# Feedback topic
+
+Date:
+Source: Anonymized external tester / study participant / contributor
+Context: Device, orientation, browser, and task
+Consent: Paraphrased for public documentation
+Status: New / accepted / implemented / validated / declined
+
+## Observations
+
+## Product interpretation
+
+## Proposed response
+
+## Evidence and links
+
+## Open questions
+```
+

--- a/aoi_kinabot_app/docs/methodology/METRIC-DEFINITIONS.md
+++ b/aoi_kinabot_app/docs/methodology/METRIC-DEFINITIONS.md
@@ -1,0 +1,41 @@
+# How KinaBot Produces the Eight Feature Indexes
+
+Model version: `score-v2-multilingual`
+
+KinaBot uses its own Python and multilingual NLP pipeline. Audio is transcribed
+privately by the application, then language-specific tokenization and acoustic
+timing evidence are used to calculate raw metrics. OpenAI does not transcribe
+the recording or calculate these scores.
+
+Each displayed value is a bounded **0–100 sample feature index**. It is not a
+percentage, probability, percentile, population ranking, health score, or
+cognitive test result.
+
+| Feature | Raw evidence | Display transformation |
+|---|---|---|
+| Vocabulary Variety | Distinct language units divided by total units | Type-token ratio mapped to 0–100 |
+| Response Length | Total recognized language units | Units relative to a language-specific pilot reference center |
+| Sentence Structure | Average units per sentence and connector count | Weighted, bounded combination of length and connectors |
+| Speech Pace | Language units and recording duration | Distance from a broad language-specific pilot center |
+| Pause Pattern | Pause ratio, count, mean, maximum, voiced and pause time | Weighted distance from broad descriptive centers |
+| Repetition Pattern | Repeated instances relative to total units | Lower repetition ratio maps to a higher display index |
+| Emotional Tone | Small language-specific positive/negative wording lexicon | Bounded balance of detected wording; topic strongly affects it |
+| Recording Clarity | Amount of recognizable transcript evidence | Tiered index based on usable recognized units |
+
+English uses regular-expression word tokens, Japanese uses Janome
+morphological analysis, and Chinese uses jieba segmentation. Pace and response
+length use language-specific pilot centers. These centers are engineering
+choices that require calibration and validation with representative consented
+data.
+
+## Longitudinal Interpretation
+
+KinaBot compares a person only with that person's earlier samples. A higher or
+lower value is not inherently healthier or worse. Small differences may be
+ordinary variation, and even sustained differences require careful research
+before any relationship with cognitive wellness can be claimed.
+
+Formula-level implementation is versioned in `scoring.py`; the broader
+methodology, limitations, and validation plan are maintained in
+`SCORING-METHODOLOGY.md`.
+

--- a/aoi_kinabot_app/docs/ux/MOBILE-FIRST-RESULTS.md
+++ b/aoi_kinabot_app/docs/ux/MOBILE-FIRST-RESULTS.md
@@ -1,0 +1,53 @@
+# Mobile-First Results Architecture
+
+## Goal
+
+An ordinary user should record or upload a sample, understand the immediate
+result, and revisit personal trends from a phone without navigating a long
+research-style page.
+
+## Participant Information Architecture
+
+```text
+Sign in
+├── Today
+│   ├── Add voice sample
+│   ├── Analyze
+│   ├── Four-dimension reflection
+│   └── Compact eight-feature snapshot
+└── Trends
+    ├── Latest eight-feature snapshot
+    ├── Feature selector
+    ├── Recent 3 / All sessions
+    ├── Descriptive change statement
+    └── Scoring methodology
+```
+
+The top-level **Today / Trends** control makes the latest result available in
+one tap after sign-in. The eight-feature snapshot uses a two-column grid on
+mobile. Trend charts show one selected feature at a time to reduce clutter and
+avoid horizontal scrolling.
+
+## Accessibility Principles
+
+- No laptop is required for the participant journey.
+- Core controls remain large enough for touch input.
+- Upload remains the default reliable audio path; direct recording is optional.
+- No result depends on color alone.
+- Detail is progressively disclosed without hiding consent or limitations.
+- The application avoids labels such as normal, abnormal, improved, declined,
+  or at risk.
+
+## Research Administration
+
+Research Admin is owner-only and must remain separated from the participant
+journey. A future dedicated admin route should use a responsive drawer or
+bottom sheet on small screens and preserve separation between private identity
+exports and de-identified research records.
+
+## Evaluation
+
+Measure task completion, time to find the latest result, taps to reach Trends,
+scroll depth, abandonment, comprehension of the 0–100 scale, and usability by
+older adults. Record only verified results in `IMPACT.md`.
+

--- a/aoi_kinabot_app/history_view.py
+++ b/aoi_kinabot_app/history_view.py
@@ -1,0 +1,40 @@
+"""Pure presentation helpers for KinaBot's longitudinal mobile views."""
+
+from __future__ import annotations
+
+from html import escape
+
+import pandas as pd
+
+from scoring import display_feature_name
+
+
+def metric_grid_html(score_items: list[dict], language: str) -> str:
+    """Return a compact two-column score grid suitable for narrow screens."""
+    tiles = []
+    for item in score_items:
+        score = int(round(float(item["score"])))
+        label = escape(display_feature_name(str(item["feature_name"]), language))
+        tiles.append(
+            f'<div class="metric-tile">'
+            f'<div class="metric-tile__top">'
+            f'<span class="metric-tile__name">{label}</span>'
+            f'<span class="metric-tile__value">{score}</span>'
+            f'</div><div class="metric-tile__track">'
+            f'<div class="metric-tile__fill" style="width:{score}%"></div>'
+            f'</div></div>'
+        )
+    return f'<div class="metric-grid">{"".join(tiles)}</div>'
+
+
+def latest_session_scores(history: pd.DataFrame) -> list[dict]:
+    """Return score rows belonging to the most recent stored session."""
+    if history.empty:
+        return []
+    if "session_id" in history.columns:
+        latest_session_id = history["session_id"].max()
+        latest = history[history["session_id"] == latest_session_id]
+        return latest.to_dict("records")
+    latest_created_at = history["created_at"].max()
+    latest = history[history["created_at"] == latest_created_at]
+    return latest.to_dict("records")

--- a/aoi_kinabot_app/test_multilingual.py
+++ b/aoi_kinabot_app/test_multilingual.py
@@ -2,10 +2,12 @@ from pathlib import Path
 from datetime import datetime, timezone
 
 import database
+import pandas as pd
 from language_analysis import LANGUAGE_CODES, analyze_transcript
 from local_time import local_date_iso
 from reflection_profile import build_reflection_profile
 from insight_service import anonymous_trend_payload, generate_wellness_insight
+from history_view import latest_session_scores, metric_grid_html
 from scoring import calculate_feature_scores, display_feature_name, tokenize
 from speech_to_text import calculate_pause_metrics
 from wellness_guidance import wellness_suggestions
@@ -222,3 +224,38 @@ def test_daily_limit_uses_browser_local_midnight(tmp_path: Path, monkeypatch):
     assert migrated == 1
     assert database.count_tests_today(user_id, "2026-07-28") == 1
     assert database.count_tests_today(user_id, "2026-07-29") == 0
+
+
+def test_mobile_metric_grid_contains_eight_compact_tiles():
+    scores = [
+        {"feature_name": name, "score": 50 + index}
+        for index, name in enumerate(
+            [
+                "Vocabulary Variety",
+                "Response Length",
+                "Sentence Complexity",
+                "Speech Pace",
+                "Pause Pattern",
+                "Repetition Pattern",
+                "Emotional Tone",
+                "Transcription Clarity",
+            ]
+        )
+    ]
+    markup = metric_grid_html(scores, "English")
+    assert markup.count('class="metric-tile"') == 8
+    assert "Vocabulary variety" in markup
+    assert "57" in markup
+
+
+def test_latest_session_scores_returns_only_most_recent_session():
+    history = pd.DataFrame(
+        [
+            {"session_id": 1, "created_at": "2026-08-02T10:00:00Z", "feature_name": "A", "score": 40},
+            {"session_id": 2, "created_at": "2026-08-02T10:00:00Z", "feature_name": "A", "score": 60},
+            {"session_id": 2, "created_at": "2026-08-02T10:00:00Z", "feature_name": "B", "score": 70},
+        ]
+    )
+    latest = latest_session_scores(history)
+    assert [item["feature_name"] for item in latest] == ["A", "B"]
+    assert [item["score"] for item in latest] == [60, 70]


### PR DESCRIPTION
## What changed

- Added a one-tap **Today / Trends** destination after sign-in.
- Added a compact two-column latest eight-feature grid for narrow screens.
- Added one-feature-at-a-time recent-three/all-session trend views.
- Added in-app explanations and a link to the versioned scoring methodology.
- Made session ordering robust when multiple sessions share the same timestamp.
- Added anonymized feedback, metric-definition, mobile UX, decision-log, and
  Purdue data science teaching-case documentation.

## Why

An anonymized external tester found the single analysis flow smooth but wanted
to understand the eight indexes, revisit recent results, and avoid excessive
portrait scrolling. This change turns that feedback into a mobile-first,
auditable product iteration without exposing participant identity or implying
medical interpretation.

## User and developer impact

Returning users can reach their latest eight features and Trends in one tap
after sign-in. A selected metric is shown by itself to keep phone charts
readable. Public documentation now connects feedback, methodology, UX reasoning,
education, and future validation work.

Research Admin remains permission-gated. A dedicated responsive admin route is
tracked as follow-up work in #26.

## Responsible boundary

Scores remain descriptive engineered indexes for a speech sample. They are not
percentages, population rankings, health scores, cognitive assessments,
diagnoses, or evidence of improvement or decline.

## Validation

- 15 automated tests passed.
- Python syntax checks passed.
- Streamlit AppTest reported zero exceptions.
- Real-browser login and Trends navigation were exercised.
- The latest result rendered exactly eight compact cards with no alert.
- Git diff whitespace checks passed.

Related to #26. Usability measurement and the responsive Research Admin
follow-up remain open.
