### PR TITLE
Add offline university research mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ __pycache__/
 aoi_kinabot_app/data/
 aoi_kinabot_app/streamlit.*.log
 aoi_kinabot_app/kinabot-*.log
+aoi_kinabot_app/.offline-participant-key
+aoi_kinabot_app/.venv/
+aoi_kinabot_app/wheelhouse/
+aoi_kinabot_app/models/
+aoi_kinabot_app/dist/

--- a/aoi_kinabot_app/.env.example
+++ b/aoi_kinabot_app/.env.example
@@ -11,6 +11,11 @@ KINABOT_MAX_AUDIO_MB=25
 KINABOT_ADMIN_KEY=replace-with-a-long-random-secret
 KINABOT_DATABASE_PATH=/data/kinabot.sqlite3
 
+# Offline research mode (no email or OpenAI; requires a local model directory)
+KINABOT_OFFLINE_RESEARCH_MODE=false
+KINABOT_OFFLINE_WHISPER_MODEL_PATH=
+KINABOT_PARTICIPANT_KEY_SECRET=
+
 # Email verification (Amazon SES SMTP in production)
 KINABOT_SMTP_HOST=email-smtp.us-west-2.amazonaws.com
 KINABOT_SMTP_PORT=587

--- a/aoi_kinabot_app/CHANGELOG.md
+++ b/aoi_kinabot_app/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-08-05 · Offline university research mode
+
+- Added school-assigned participant IDs without email collection or SMTP.
+- Added study-secret HMAC pseudonyms so low-entropy IDs such as `001` are not
+  stored or represented by enumerable unkeyed hashes.
+- Enforced local Whisper model paths and disabled OpenAI in offline mode.
+- Added offline-only dependencies, installation, launch, bundle-build, checksum,
+  verification, quick-start, and acceptance-test materials.
+- Added UK/EU data-protection readiness and a university/Purdue data-science
+  milestone record without claiming institutional approval or legal compliance.
+
 ## 2026-08-03 · 30-day pattern experience
 
 - Added the multilingual **30 Days to Know Your Patterns** experience.

--- a/aoi_kinabot_app/OFFLINE-QUICKSTART.md
+++ b/aoi_kinabot_app/OFFLINE-QUICKSTART.md
@@ -1,0 +1,35 @@
+# KinaBot Offline Research — Quick Start
+
+## For the Study Administrator
+
+1. Copy the complete approved KinaBot offline bundle to the encrypted research
+   computer.
+2. Confirm these folders exist:
+   - `wheelhouse/`
+   - `models/whisper-small/`
+3. Open PowerShell in this folder.
+4. Run `Set-ExecutionPolicy -Scope Process Bypass` if institution policy allows.
+5. Run `.\install-offline.ps1` once.
+6. Disconnect the computer from the network if required by the protocol.
+7. Run `.\run-offline.ps1`.
+8. Open `http://127.0.0.1:8501`.
+
+## For a Participant
+
+1. Enter the ID assigned by the university, for example `001`.
+2. Select English, Japanese, or Chinese.
+3. Read and accept the study/product consent shown by the approved protocol.
+4. Select the approved audio recording.
+5. Review the descriptive speech features.
+
+Do not enter a name or email. The research team must keep the separate ID key
+outside KinaBot. KinaBot does not diagnose, screen for disease, or provide
+medical advice.
+
+## Stop the App
+
+Return to the PowerShell window and press `Ctrl+C`.
+
+For installation validation, data governance, and troubleshooting, see
+`docs/OFFLINE-RESEARCH-GUIDE.md` and
+`docs/UK-EU-DATA-PROTECTION-READINESS.md`.

--- a/aoi_kinabot_app/README.md
+++ b/aoi_kinabot_app/README.md
@@ -71,6 +71,21 @@ Project records:
 - [Founder and maintainership](OWNERSHIP-AND-MAINTAINERSHIP.md)
 - [V1.1 release checklist](RELEASE-CHECKLIST.md)
 
+## Offline University Research Mode
+
+KinaBot can run without email, SMTP, OpenAI, or cloud transcription. An approved
+offline bundle uses a preinstalled local Whisper model, local SQLite storage,
+and school-assigned participant IDs such as `001`. The raw ID is not stored;
+KinaBot derives a study-specific HMAC pseudonym using a locally generated secret.
+
+Start with [Offline Quick Start](OFFLINE-QUICKSTART.md). Research administrators
+should also review the [offline research guide](docs/OFFLINE-RESEARCH-GUIDE.md),
+[UK/EU data-protection readiness checklist](docs/UK-EU-DATA-PROTECTION-READINESS.md),
+and [bundle manifest](docs/OFFLINE-BUNDLE-MANIFEST.md).
+
+Offline engineering controls support—but do not replace—university ethics,
+information-governance, legal, security, and study-protocol approval.
+
 ## OpenAI's Limited Role
 
 OpenAI is an optional insight layer used only after KinaBot has calculated the

--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -16,6 +16,8 @@ from config import (
     CONSENT_VERSION,
     MAX_AUDIO_BYTES,
     MAX_TESTS_PER_DAY,
+    OFFLINE_RESEARCH_MODE,
+    PARTICIPANT_KEY_SECRET,
     SCORING_MODEL_VERSION,
 )
 from database import (
@@ -41,6 +43,7 @@ from history_view import latest_session_scores, metric_grid_html
 from insight_service import generate_wellness_insight
 from language_analysis import LANGUAGE_CODES, analyze_transcript
 from local_time import local_date_iso
+from offline_identity import normalize_participant_id, participant_key, valid_participant_id
 from speech_to_text import (
     LOCAL_TRANSCRIPTION_TYPES,
     speech_to_text_configured,
@@ -270,6 +273,27 @@ LANDING_COPY = {
     },
 }
 
+OFFLINE_LOGIN_COPY = {
+    "English": {
+        "caption": "Offline research mode: enter the participant ID assigned by the study administrator.",
+        "label": "Participant ID",
+        "continue": "Continue offline",
+        "invalid": "Use 3-32 letters, numbers, underscores, or hyphens.",
+    },
+    "日本語": {
+        "caption": "オフライン研究モード：研究担当者から割り当てられた参加者IDを入力してください。",
+        "label": "参加者ID",
+        "continue": "オフラインで続ける",
+        "invalid": "3〜32文字の英数字、アンダースコア、またはハイフンを使用してください。",
+    },
+    "中文": {
+        "caption": "离线研究模式：请输入研究管理员分配的参与者编号。",
+        "label": "参与者编号",
+        "continue": "离线继续",
+        "invalid": "请使用3至32位字母、数字、下划线或连字符。",
+    },
+}
+
 AUDIO_CAPTURE_COPY = {
     "English": {
         "new": "New reflection",
@@ -462,6 +486,45 @@ if "profile" not in st.session_state:
     st.session_state.profile = None
 if not st.session_state.verified:
     st.subheader(copy["start"])
+    if OFFLINE_RESEARCH_MODE:
+        offline_copy = OFFLINE_LOGIN_COPY[st.session_state.ui_language]
+        st.info("🔒 Offline research mode · no email · no cloud AI")
+        st.caption(offline_copy["caption"])
+        participant_id = st.text_input(offline_copy["label"])
+        if st.button(offline_copy["continue"], type="primary", use_container_width=True):
+            if not valid_participant_id(participant_id):
+                st.error(offline_copy["invalid"])
+            else:
+                normalized_id = normalize_participant_id(participant_id)
+                if len(PARTICIPANT_KEY_SECRET) < 32:
+                    st.error(
+                        "Offline participant-key secret is missing. Ask the study "
+                        "administrator to run install-offline.ps1."
+                    )
+                    st.stop()
+                pseudonymous_key = participant_key(
+                    normalized_id, PARTICIPANT_KEY_SECRET
+                )
+                user_id = upsert_user(pseudonymous_key, email=None)
+                profile = get_user_profile(user_id)
+                if not profile or not profile["display_name"]:
+                    update_user_profile(
+                        user_id,
+                        "Offline participant",
+                        "Prefer not to say",
+                        "Prefer not to say",
+                        None,
+                        None,
+                    )
+                st.session_state.email = f"Participant {normalized_id}"
+                st.session_state.email_hash = pseudonymous_key
+                st.session_state.user_id = user_id
+                st.session_state.profile = dict(get_user_profile(user_id))
+                st.session_state.verified = True
+                st.rerun()
+        st.caption(copy["disclaimer"])
+        st.stop()
+
     st.caption(copy["login_caption"])
     email = st.text_input(copy["email"], value=st.session_state.email)
     if not st.session_state.code_sent:

--- a/aoi_kinabot_app/build-offline-bundle.ps1
+++ b/aoi_kinabot_app/build-offline-bundle.ps1
@@ -1,0 +1,43 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$WheelhousePath,
+    [Parameter(Mandatory = $true)]
+    [string]$WhisperModelPath,
+    [string]$OutputDirectory = "$PSScriptRoot\dist"
+)
+
+$ErrorActionPreference = "Stop"
+$wheelhouse = Resolve-Path -LiteralPath $WheelhousePath -ErrorAction Stop
+$model = Resolve-Path -LiteralPath $WhisperModelPath -ErrorAction Stop
+$repoRoot = Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..")
+$commit = (& git -C $repoRoot.Path rev-parse --short=12 HEAD).Trim()
+if (-not $commit) { throw "Unable to determine the Git commit." }
+
+$output = New-Item -ItemType Directory -Force -Path $OutputDirectory
+$stage = Join-Path $output.FullName "KinaBot-Offline-$commit"
+$archive = Join-Path $output.FullName "source-$commit.zip"
+if (Test-Path -LiteralPath $stage) {
+    throw "Bundle staging directory already exists: $stage"
+}
+
+& git -C $repoRoot.Path archive --format=zip --output=$archive HEAD aoi_kinabot_app
+Expand-Archive -LiteralPath $archive -DestinationPath $output.FullName
+Move-Item -LiteralPath (Join-Path $output.FullName "aoi_kinabot_app") -Destination $stage
+Remove-Item -LiteralPath $archive
+
+Copy-Item -LiteralPath $wheelhouse.Path -Destination (Join-Path $stage "wheelhouse") -Recurse
+New-Item -ItemType Directory -Force -Path (Join-Path $stage "models") | Out-Null
+Copy-Item -LiteralPath $model.Path -Destination (Join-Path $stage "models\whisper-small") -Recurse
+
+$manifestPath = Join-Path $stage "SHA256SUMS.csv"
+$rows = Get-ChildItem -LiteralPath $stage -Recurse -File | ForEach-Object {
+    $relative = $_.FullName.Substring($stage.Length + 1)
+    $hash = Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256
+    [pscustomobject]@{ Path = $relative; SHA256 = $hash.Hash; Bytes = $_.Length }
+}
+$rows | Export-Csv -LiteralPath $manifestPath -NoTypeInformation -Encoding utf8
+
+$zipPath = "$stage.zip"
+Compress-Archive -LiteralPath $stage -DestinationPath $zipPath
+Write-Host "Created $zipPath"
+Write-Host "Commit $commit; files $($rows.Count)"

--- a/aoi_kinabot_app/config.py
+++ b/aoi_kinabot_app/config.py
@@ -3,14 +3,22 @@
 import os
 from pathlib import Path
 
-APP_VERSION = "v1.1-multilingual-pilot"
+APP_VERSION = "v1.2-offline-research"
 CONSENT_VERSION = "consent-v1.1"
 SCORING_MODEL_VERSION = "score-v2-multilingual"
 OPENAI_INSIGHT_MODEL = os.getenv("KINABOT_INSIGHT_MODEL", "gpt-5.6-luna")
 ENVIRONMENT = os.getenv("KINABOT_ENVIRONMENT", "development").strip().lower()
+OFFLINE_RESEARCH_MODE = (
+    os.getenv("KINABOT_OFFLINE_RESEARCH_MODE", "false").strip().lower() == "true"
+)
+OFFLINE_WHISPER_MODEL_PATH = os.getenv(
+    "KINABOT_OFFLINE_WHISPER_MODEL_PATH", ""
+).strip()
+PARTICIPANT_KEY_SECRET = os.getenv("KINABOT_PARTICIPANT_KEY_SECRET", "").strip()
 ALLOW_LOCAL_VERIFICATION_CODES = (
     os.getenv("KINABOT_ALLOW_LOCAL_CODES", "true").strip().lower() == "true"
     and ENVIRONMENT != "production"
+    and not OFFLINE_RESEARCH_MODE
 )
 ADMIN_KEY = os.getenv("KINABOT_ADMIN_KEY", "").strip()
 

--- a/aoi_kinabot_app/docs/AI-RISK-REGISTER.md
+++ b/aoi_kinabot_app/docs/AI-RISK-REGISTER.md
@@ -40,6 +40,9 @@ non-diagnostic boundary blocks release until reviewed and accepted in writing.
 | R-18 | Service becomes financially or operationally unsustainable | 3×3 | Usage limits; local scoring; container/AWS direction | 2×3 | Cost per active user, support burden, uptime, and funding model tracking | Open |
 | R-19 | Users rely on KinaBot during urgent health or safety concerns | 2×5 | Not emergency support; professional-care direction | 1×5 | Test visibility and comprehension of urgent-use boundary | Controlled; monitor |
 | R-20 | Environmental cost grows without corresponding public value | 2×3 | Local deterministic scoring; limited optional LLM use | 1×3 | Track compute per completed reflection and avoid unnecessary inference | Open |
+| R-21 | Low-entropy school IDs are guessed from an unkeyed hash | 4×4 | Study-secret HMAC pseudonyms; raw IDs not persisted | 1×4 | Verify secret generation, separation, access, and backup in each installation | Controlled; monitor |
+| R-22 | Loss or replacement of the study secret breaks longitudinal linkage | 3×4 | Installer creates a persistent local secret; launcher requires it | 2×4 | Institution-approved encrypted backup and recovery exercise | Open |
+| R-23 | An offline instance is accidentally exposed on a network | 3×5 | Launcher binds to `127.0.0.1`; offline acceptance test requires network review | 1×5 | University firewall/device review and port verification | Controlled; monitor |
 
 ## Release Review
 

--- a/aoi_kinabot_app/docs/DECISION-LOG.md
+++ b/aoi_kinabot_app/docs/DECISION-LOG.md
@@ -22,6 +22,7 @@ considered.
 | 2026-08-02 | Publish anonymized feedback and scoring explanations | Make design reasoning educational and auditable without exposing participant identity or overstating evidence |
 | 2026-08-03 | Introduce a low-pressure 30-day pattern experience with one recommended daily reflection | Make the value understandable before asking for repeated use; keep extra check-ins optional and avoid streak penalties |
 | 2026-08-05 | Establish validation gates, an active AI risk register, and evidence-defined impact metrics | Make future releases, pilots, public claims, and independent evaluation follow one auditable human-centered framework |
+| 2026-08-05 | Create an offline university research mode with school IDs, study-secret HMAC pseudonyms, and mandatory local transcription | Support privacy-sensitive UK and university research without email, cloud scoring, or silent model downloads |
 
 ## Template for Future Decisions
 

--- a/aoi_kinabot_app/docs/OFFLINE-BUNDLE-MANIFEST.md
+++ b/aoi_kinabot_app/docs/OFFLINE-BUNDLE-MANIFEST.md
@@ -1,0 +1,22 @@
+# Offline Research Bundle Manifest
+
+Every university delivery must identify:
+
+- KinaBot Git commit and release;
+- application and scoring-model versions;
+- supported operating system and Python version;
+- exact wheelhouse contents and licenses;
+- faster-whisper/CTranslate2 model name, source, version, license, and SHA-256;
+- bundle SHA-256 manifest;
+- build date and builder;
+- institution and approved research purpose;
+- offline acceptance-test result;
+- known limitations; and
+- contact for security or data-protection issues.
+
+`build-offline-bundle.ps1` creates a commit-specific ZIP and file manifest from
+an approved wheelhouse and model directory. `verify-offline-bundle.ps1` checks
+that required components exist and that every manifested file is unchanged.
+
+The generated bundle, model, wheelhouse, participant-key secret, databases, and
+research exports must not be committed to the public repository.

--- a/aoi_kinabot_app/docs/OFFLINE-RESEARCH-GUIDE.md
+++ b/aoi_kinabot_app/docs/OFFLINE-RESEARCH-GUIDE.md
@@ -1,0 +1,72 @@
+# KinaBot Offline Research Mode
+
+Offline Research Mode supports university research on one approved computer or
+trusted local network. Speech processing and longitudinal records remain under
+the research institution's control.
+
+## What Offline Mode Enforces
+
+When `KINABOT_OFFLINE_RESEARCH_MODE=true`:
+
+- participants use a school-assigned ID such as `001`, not an email address;
+- the database stores a keyed, study-specific HMAC pseudonym rather than the raw ID;
+- email and SMTP verification are bypassed;
+- OpenAI is disabled even if an API key is present;
+- transcription requires an existing local Whisper model directory;
+- KinaBot does not request a model download by name;
+- feature scoring, longitudinal history, and research export stay local; and
+- raw audio and full transcripts are not retained by KinaBot.
+
+The installer generates a local participant-key secret. It must be protected
+with the same care as the database and backed up securely; losing or changing it
+breaks linkage to prior sessions. The institution must keep the human
+participant-to-ID key separately. KinaBot's UI
+may display research-source links, but it never opens them automatically.
+
+## Prepare the Offline Package
+
+On an approved internet-connected administration computer:
+
+```powershell
+python -m pip download -r requirements-offline.txt -d wheelhouse
+```
+
+Also obtain a compatible CTranslate2/faster-whisper model directory. Copy the
+repository, wheelhouse, and model to institution-approved encrypted media.
+Record file hashes, licenses, the Git commit, and the scoring version.
+
+## Install Without Internet
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --no-index --find-links .\wheelhouse -r requirements-offline.txt
+```
+
+Start with an explicit local model path:
+
+```powershell
+.\run-offline.ps1 -WhisperModelPath "D:\KinaBot\models\whisper-small"
+```
+
+Open `http://127.0.0.1:8501`. Participant IDs must contain 3-32 letters,
+numbers, underscores, or hyphens. `001` is valid.
+
+## Offline Acceptance Test
+
+1. Disconnect wired, wireless, and VPN network access.
+2. Start KinaBot with `run-offline.ps1`.
+3. Enter test ID `001` and confirm no email or verification code is requested.
+4. Analyze a non-sensitive test recording twice.
+5. Confirm local results and longitudinal history.
+6. Confirm no raw audio or full transcript remains after processing.
+7. Export and inspect the de-identified research CSV.
+8. Record the app commit, model hash/path, scoring version, OS, and result.
+
+## Research Responsibility
+
+Offline operation does not by itself establish GDPR compliance, clinical
+validity, ethics approval, or regulatory clearance. The university remains
+responsible for its lawful basis, ethics review, participant information,
+retention schedule, device security, backups, deletion, incident response, and
+appropriate interpretation.

--- a/aoi_kinabot_app/docs/PROJECT-EVOLUTION.md
+++ b/aoi_kinabot_app/docs/PROJECT-EVOLUTION.md
@@ -121,3 +121,15 @@ The following records should be read together:
 
 Future claims of adoption, clinical utility, independent replication, or
 field-wide impact must be supported by separate third-party evidence.
+
+## 8. Offline University Research Mode
+
+In August 2026, Aoi Minamoto developed a separate offline research path in
+response to interest in university use. It removes email verification, accepts
+school-assigned IDs, stores study-secret HMAC pseudonyms, disables SMTP and
+OpenAI, and requires an existing local speech model so the application cannot
+silently download one. The work includes local installation and launch scripts,
+checksum-based bundle controls, an offline acceptance procedure, UK/EU
+data-protection readiness documentation, and a Purdue Online Data Science
+milestone record. Institutional adoption or approval must be documented
+separately if it occurs.

--- a/aoi_kinabot_app/docs/README.md
+++ b/aoi_kinabot_app/docs/README.md
@@ -16,12 +16,16 @@ what a voice sample can prove.
 - [Validation Plan](VALIDATION-PLAN.md)
 - [AI Risk Register](AI-RISK-REGISTER.md)
 - [Impact Metrics and Evidence Rules](IMPACT-METRICS.md)
+- [Offline Research Mode](OFFLINE-RESEARCH-GUIDE.md)
+- [Offline Bundle Manifest](OFFLINE-BUNDLE-MANIFEST.md)
+- [UK/EU Data-Protection Readiness](UK-EU-DATA-PROTECTION-READINESS.md)
 - [Decision Log](DECISION-LOG.md)
 - [Project Evolution and Continuing Contribution](PROJECT-EVOLUTION.md)
 - [Public User Feedback](feedback/README.md)
 - [Eight Feature Definitions](methodology/METRIC-DEFINITIONS.md)
 - [Mobile-First Results Architecture](ux/MOBILE-FIRST-RESULTS.md)
 - [Purdue Data Science Teaching Case](education/PURDUE-DATA-SCIENCE-CASE-STUDY.md)
+- [University Offline Research Milestone](education/UNIVERSITY-OFFLINE-RESEARCH-MILESTONE.md)
 
 Technical references remain in the application root:
 

--- a/aoi_kinabot_app/docs/UK-EU-DATA-PROTECTION-READINESS.md
+++ b/aoi_kinabot_app/docs/UK-EU-DATA-PROTECTION-READINESS.md
@@ -1,0 +1,72 @@
+# UK and EU University Research Data-Protection Readiness
+
+Status: engineering readiness checklist, not legal certification
+
+KinaBot Offline Research Mode is designed to support a university's UK GDPR,
+EU GDPR, ethics, and information-security review. The university remains the
+data controller unless its written arrangement determines otherwise. AImoji LLC
+and any participating researcher must document their actual roles before data
+collection.
+
+## Implemented Privacy-by-Design Controls
+
+| Principle | Offline-mode control |
+|---|---|
+| Purpose limitation | Mode is limited to approved speech-reflection research; no diagnostic or employment use |
+| Data minimisation | No email is required; school ID is hashed; raw audio and full transcript are not retained |
+| Pseudonymisation | A study-secret HMAC key links sessions without storing the assigned ID |
+| Local control | SQLite, transcription, scoring, and exports remain on the approved research computer |
+| External transfer reduction | SMTP and OpenAI are disabled; local model path is mandatory |
+| Transparency | UI states offline mode and non-medical boundaries; study notice remains the university's responsibility |
+| Accuracy and interpretation | Versioned descriptive features; no diagnosis or disease-risk claim |
+| Security | Local-only default bind, explicit model path, temporary-file deletion, and separate re-identification key |
+| Accountability | Git version, scoring version, validation log, risk register, and study acceptance test |
+
+Pseudonymised data remains personal data when the university can reconnect it
+to a participant. It must not be described as anonymous solely because KinaBot
+does not store the original ID.
+
+## Required Before a UK University Study
+
+The university's principal investigator, ethics body, Information Governance
+team, and Data Protection Officer should determine and document:
+
+- research purpose and protocol;
+- controller, joint-controller, and processor roles;
+- Article 6 lawful basis;
+- Article 9 condition if health or other special-category data is processed;
+- whether a Data Protection Impact Assessment is required;
+- participant information and research-consent process;
+- whether participation consent differs from the data-processing lawful basis;
+- retention, deletion, withdrawal, access, and correction procedures;
+- device encryption, physical security, backups, and incident response;
+- who holds the participant-ID linkage key;
+- whether any data leaves the UK/EEA and the applicable transfer mechanism;
+- minimum cell sizes and disclosure controls for publications; and
+- prohibition on decisions or measures about individual participants based on
+  exploratory KinaBot results.
+
+## Recommended Institutional Configuration
+
+- Generate non-meaningful IDs such as `001`, `002`, and `003`.
+- Store the linkage file in a separate approved system with narrower access.
+- Keep KinaBot's database on an encrypted, managed device.
+- Use a dedicated OS account without general browsing or email.
+- Disable network adapters during collection if the protocol requires air-gap
+  operation.
+- Restrict research export access to named study personnel.
+- Record every export and deletion.
+- Destroy the linkage key and/or local dataset according to the approved
+  retention schedule.
+
+## Official Review References
+
+- UK Information Commissioner's Office, *The research provisions*:
+  https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/the-research-provisions/
+- ICO, *Principles and grounds for processing*:
+  https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/the-research-provisions/principles-and-grounds-for-processing/
+- ICO, *Special category data*:
+  https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/special-category-data/what-are-the-rules-on-special-category-data/
+
+ICO guidance is evolving following the UK Data (Use and Access) Act 2025. The
+university should use the current guidance at the time of protocol approval.

--- a/aoi_kinabot_app/docs/VALIDATION-PLAN.md
+++ b/aoi_kinabot_app/docs/VALIDATION-PLAN.md
@@ -162,6 +162,8 @@ not evidence of health benefit.
 | Prospective real-world pilot | Not completed |
 | Independent replication | Not completed |
 | Clinical validity | Not claimed and not established |
+| Offline ID/no-email workflow | Automated AppTest passed with synthetic ID `001` |
+| Complete disconnected transcription bundle | Pending approved model and wheelhouse acquisition |
 
 ## Standards Alignment
 

--- a/aoi_kinabot_app/docs/education/UNIVERSITY-OFFLINE-RESEARCH-MILESTONE.md
+++ b/aoi_kinabot_app/docs/education/UNIVERSITY-OFFLINE-RESEARCH-MILESTONE.md
@@ -1,0 +1,79 @@
+# University Offline Research Mode — Data Science Milestone
+
+Date established: 2026-08-05
+
+## Milestone Purpose
+
+This milestone records the development of a reproducible offline research mode
+for two educational and research contexts:
+
+1. a prospective UK university researcher who requested local/offline KinaBot
+   use; and
+2. the Purdue University Online Data Science educational record planned for the
+   fall academic term.
+
+No university endorsement, formal partnership, ethics approval, or deployment
+is implied unless supported by a separate institutional document.
+
+## Data Science Problem
+
+Create a longitudinal multilingual speech-feature workflow that can operate
+without cloud transcription, email identity, or generative-AI dependence while
+preserving reproducibility and research governance.
+
+## Engineering Deliverables
+
+- school-assigned pseudonymous participant IDs, including values such as `001`;
+- one-way domain-separated account keys with no raw ID stored in KinaBot;
+- local SQLite longitudinal records;
+- mandatory preinstalled local Whisper model;
+- offline-only dependency manifest and launcher;
+- code-level disabling of SMTP and OpenAI paths;
+- de-identified research export;
+- UK/EU data-protection readiness checklist;
+- offline acceptance procedure; and
+- automated tests covering identity, model, and external-service boundaries.
+
+## Learning Outcomes
+
+Students should be able to explain and evaluate:
+
+- pseudonymisation versus anonymisation;
+- data minimisation and purpose limitation;
+- reproducible software and model versioning;
+- offline dependency packaging;
+- longitudinal data design;
+- multilingual measurement limitations;
+- separation of deterministic analytics from generative AI;
+- privacy, fairness, and human-centered risk controls; and
+- the difference between engineering readiness, research ethics approval, and
+  legal compliance.
+
+## Evidence to Preserve
+
+- originating researcher request, with permission and appropriate redaction;
+- dated issue/design record and Git branch;
+- commits, pull request, reviews, and test results;
+- exact offline package manifest and file hashes;
+- demonstration screenshots or recording using synthetic/non-sensitive data;
+- university feedback and requested changes;
+- ethics/DPO decisions if a study proceeds;
+- independent installation and acceptance result; and
+- subsequent educational use, citation, or adoption records.
+
+## Completion Criteria
+
+The engineering milestone is complete only when a clean test environment can:
+
+1. install from a local wheelhouse;
+2. start with all network access disconnected;
+3. accept participant ID `001` without email;
+4. transcribe a non-sensitive sample from a local model;
+5. calculate and persist feature results;
+6. display longitudinal history;
+7. export de-identified records;
+8. demonstrate that OpenAI and SMTP were not called; and
+9. pass the documented privacy and file-retention inspection.
+
+Institutional deployment remains a separate milestone requiring university
+approval and independent acceptance.

--- a/aoi_kinabot_app/insight_service.py
+++ b/aoi_kinabot_app/insight_service.py
@@ -6,7 +6,7 @@ import json
 import os
 from typing import Any
 
-from config import OPENAI_INSIGHT_MODEL
+from config import OFFLINE_RESEARCH_MODE, OPENAI_INSIGHT_MODEL
 from wellness_guidance import (
     MEDITERRANEAN_TRIAL,
     SOCIAL_ENGAGEMENT_STUDY,
@@ -115,7 +115,11 @@ def _fallback_action(language: str, payload: dict) -> dict:
 def generate_wellness_insight(history: list[dict[str, Any]], language: str) -> dict:
     """Generate one action; OpenAI sees anonymous score series and allowed actions only."""
     payload = anonymous_trend_payload(history, language)
-    if payload["sessions_compared"] < 3 or not os.getenv("OPENAI_API_KEY", "").strip():
+    if (
+        OFFLINE_RESEARCH_MODE
+        or payload["sessions_compared"] < 3
+        or not os.getenv("OPENAI_API_KEY", "").strip()
+    ):
         return _fallback_action(language, payload)
 
     from openai import OpenAI

--- a/aoi_kinabot_app/install-offline.ps1
+++ b/aoi_kinabot_app/install-offline.ps1
@@ -1,0 +1,35 @@
+param(
+    [string]$PythonCommand = "python"
+)
+
+$ErrorActionPreference = "Stop"
+$appRoot = $PSScriptRoot
+$wheelhouse = Join-Path $appRoot "wheelhouse"
+$modelPath = Join-Path $appRoot "models\whisper-small"
+$venvPython = Join-Path $appRoot ".venv\Scripts\python.exe"
+$secretPath = Join-Path $appRoot ".offline-participant-key"
+
+if (-not (Test-Path -LiteralPath $wheelhouse -PathType Container)) {
+    throw "Missing wheelhouse. Ask the package administrator for the complete offline bundle."
+}
+if (-not (Test-Path -LiteralPath $modelPath -PathType Container)) {
+    throw "Missing local Whisper model at models\whisper-small."
+}
+
+& $PythonCommand -m venv (Join-Path $appRoot ".venv")
+& $venvPython -m pip install --no-index --find-links $wheelhouse `
+    -r (Join-Path $appRoot "requirements-offline.txt")
+& $venvPython -m pytest --version 2>$null
+
+if (-not (Test-Path -LiteralPath $secretPath -PathType Leaf)) {
+    $bytes = New-Object byte[] 48
+    [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+    [System.IO.File]::WriteAllText(
+        $secretPath,
+        [Convert]::ToBase64String($bytes),
+        [System.Text.UTF8Encoding]::new($false)
+    )
+}
+
+Write-Host "KinaBot offline installation completed."
+Write-Host "Run .\run-offline.ps1 to start."

--- a/aoi_kinabot_app/offline_identity.py
+++ b/aoi_kinabot_app/offline_identity.py
@@ -1,0 +1,32 @@
+"""Pseudonymous identity helpers for offline research use."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import re
+
+
+PARTICIPANT_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{2,31}$")
+
+
+def normalize_participant_id(value: str) -> str:
+    return value.strip().upper()
+
+
+def valid_participant_id(value: str) -> bool:
+    return bool(PARTICIPANT_ID_PATTERN.fullmatch(normalize_participant_id(value)))
+
+
+def participant_key(value: str, secret: str) -> str:
+    """Return a keyed pseudonym without retaining the participant ID."""
+    normalized = normalize_participant_id(value)
+    if not valid_participant_id(normalized):
+        raise ValueError("Participant ID must be 3-32 letters, numbers, _ or -.")
+    if len(secret) < 32:
+        raise ValueError("Participant-key secret must contain at least 32 characters.")
+    return hmac.new(
+        secret.encode("utf-8"),
+        f"kinabot-offline:{normalized}".encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()

--- a/aoi_kinabot_app/requirements-offline.txt
+++ b/aoi_kinabot_app/requirements-offline.txt
@@ -1,0 +1,7 @@
+streamlit>=1.40.0
+pandas>=2.0.0
+faster-whisper>=1.1.0
+jieba>=0.42.1
+janome>=0.5.0
+tzdata>=2026.1
+pytest>=8.0.0

--- a/aoi_kinabot_app/run-offline.ps1
+++ b/aoi_kinabot_app/run-offline.ps1
@@ -1,0 +1,31 @@
+param(
+    [string]$WhisperModelPath = "$PSScriptRoot\models\whisper-small",
+    [string]$DatabasePath = "$PSScriptRoot\data\kinabot_offline.sqlite3",
+    [int]$Port = 8501
+)
+
+$ErrorActionPreference = "Stop"
+$resolvedModel = Resolve-Path -LiteralPath $WhisperModelPath -ErrorAction Stop
+$offlinePython = Join-Path $PSScriptRoot ".venv\Scripts\python.exe"
+$secretPath = Join-Path $PSScriptRoot ".offline-participant-key"
+if (-not (Test-Path -LiteralPath $offlinePython -PathType Leaf)) {
+    throw "Offline environment not installed. Run .\install-offline.ps1 first."
+}
+if (-not (Test-Path -LiteralPath $secretPath -PathType Leaf)) {
+    throw "Offline participant-key secret is missing. Run .\install-offline.ps1."
+}
+$env:KINABOT_OFFLINE_RESEARCH_MODE = "true"
+$env:KINABOT_OFFLINE_WHISPER_MODEL_PATH = $resolvedModel.Path
+$env:KINABOT_DATABASE_PATH = $DatabasePath
+$env:KINABOT_ENVIRONMENT = "offline"
+$env:KINABOT_PARTICIPANT_KEY_SECRET = (
+    Get-Content -LiteralPath $secretPath -Raw
+).Trim()
+$env:KINABOT_ALLOW_LOCAL_CODES = "false"
+Remove-Item Env:OPENAI_API_KEY -ErrorAction SilentlyContinue
+
+& $offlinePython -m streamlit run "$PSScriptRoot\app.py" `
+    --server.address=127.0.0.1 `
+    --server.port=$Port `
+    --server.headless=true `
+    --browser.gatherUsageStats=false

--- a/aoi_kinabot_app/speech_to_text.py
+++ b/aoi_kinabot_app/speech_to_text.py
@@ -8,20 +8,35 @@ from functools import lru_cache
 from pathlib import Path
 from typing import BinaryIO
 
+from config import OFFLINE_RESEARCH_MODE, OFFLINE_WHISPER_MODEL_PATH
+
 
 LOCAL_TRANSCRIPTION_TYPES = ["mp3", "mp4", "mpeg", "mpga", "m4a", "wav", "webm"]
 
 
 def speech_to_text_configured() -> bool:
     """Local transcription is part of the app and needs no external API key."""
-    return True
+    if not OFFLINE_RESEARCH_MODE:
+        return True
+    return bool(
+        OFFLINE_WHISPER_MODEL_PATH
+        and Path(OFFLINE_WHISPER_MODEL_PATH).expanduser().is_dir()
+    )
 
 
 @lru_cache(maxsize=1)
 def _local_model():
     from faster_whisper import WhisperModel
 
-    model_name = os.getenv("KINABOT_WHISPER_MODEL", "small")
+    if OFFLINE_RESEARCH_MODE:
+        if not speech_to_text_configured():
+            raise RuntimeError(
+                "Offline Whisper model not found. Set "
+                "KINABOT_OFFLINE_WHISPER_MODEL_PATH to a local model directory."
+            )
+        model_name = str(Path(OFFLINE_WHISPER_MODEL_PATH).expanduser().resolve())
+    else:
+        model_name = os.getenv("KINABOT_WHISPER_MODEL", "small")
     compute_type = os.getenv("KINABOT_WHISPER_COMPUTE_TYPE", "int8")
     return WhisperModel(model_name, device="cpu", compute_type=compute_type)
 
@@ -32,6 +47,14 @@ def transcribe_audio_upload(
     language_code: str,
 ) -> tuple[bool, str, float | None, dict]:
     """Transcribe locally and delete the temporary audio file in every outcome."""
+    if not speech_to_text_configured():
+        return (
+            False,
+            "Offline Whisper model is not configured. Ask the study administrator "
+            "to set KINABOT_OFFLINE_WHISPER_MODEL_PATH.",
+            None,
+            {},
+        )
     suffix = Path(original_name).suffix or ".audio"
     temp_path: Path | None = None
     try:

--- a/aoi_kinabot_app/test_offline_mode.py
+++ b/aoi_kinabot_app/test_offline_mode.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+import insight_service
+import speech_to_text
+from offline_identity import participant_key, valid_participant_id
+
+TEST_SECRET = "test-only-secret-that-is-at-least-32-characters"
+
+
+def test_school_participant_id_001_is_valid_and_not_stored_in_key():
+    assert valid_participant_id("001")
+    key = participant_key("001", TEST_SECRET)
+    assert key != "001"
+    assert "001" not in key
+    assert len(key) == 64
+
+
+def test_participant_ids_are_limited_and_normalized():
+    assert participant_key(" study-01 ", TEST_SECRET) == participant_key(
+        "STUDY-01", TEST_SECRET
+    )
+    assert not valid_participant_id("01")
+    assert not valid_participant_id("participant@example.org")
+    assert not valid_participant_id("name with spaces")
+
+
+def test_different_studies_get_different_pseudonyms():
+    assert participant_key("001", TEST_SECRET) != participant_key(
+        "001", "different-study-secret-that-is-32-characters"
+    )
+
+
+def test_offline_mode_uses_local_action_even_when_api_key_exists(monkeypatch):
+    monkeypatch.setattr(insight_service, "OFFLINE_RESEARCH_MODE", True)
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-be-used")
+    history = [
+        {
+            "feature_name": "Expression Variety",
+            "score": score,
+            "created_at": f"2026-08-0{index}",
+            "session_number": index,
+        }
+        for index, score in enumerate([60, 58, 57], start=1)
+    ]
+
+    result = insight_service.generate_wellness_insight(history, "English")
+
+    assert result["generated_by"] == "KinaBot research action library"
+
+
+def test_offline_transcription_requires_existing_local_model(tmp_path, monkeypatch):
+    monkeypatch.setattr(speech_to_text, "OFFLINE_RESEARCH_MODE", True)
+    monkeypatch.setattr(
+        speech_to_text,
+        "OFFLINE_WHISPER_MODEL_PATH",
+        str(tmp_path / "missing-model"),
+    )
+    assert speech_to_text.speech_to_text_configured() is False
+
+    model_dir = tmp_path / "local-model"
+    model_dir.mkdir()
+    monkeypatch.setattr(
+        speech_to_text,
+        "OFFLINE_WHISPER_MODEL_PATH",
+        str(model_dir),
+    )
+    assert speech_to_text.speech_to_text_configured() is True
+
+
+def test_missing_offline_model_fails_before_reading_audio(tmp_path, monkeypatch):
+    monkeypatch.setattr(speech_to_text, "OFFLINE_RESEARCH_MODE", True)
+    monkeypatch.setattr(
+        speech_to_text,
+        "OFFLINE_WHISPER_MODEL_PATH",
+        str(tmp_path / "missing-model"),
+    )
+    ok, message, duration, metrics = speech_to_text.transcribe_audio_upload(
+        object(), "sample.wav", "en"
+    )
+    assert ok is False
+    assert "Offline Whisper model" in message
+    assert duration is None
+    assert metrics == {}

--- a/aoi_kinabot_app/verify-offline-bundle.ps1
+++ b/aoi_kinabot_app/verify-offline-bundle.ps1
@@ -1,0 +1,33 @@
+param(
+    [string]$BundlePath = $PSScriptRoot
+)
+
+$ErrorActionPreference = "Stop"
+$bundle = Resolve-Path -LiteralPath $BundlePath -ErrorAction Stop
+$required = @(
+    "app.py",
+    "install-offline.ps1",
+    "run-offline.ps1",
+    "requirements-offline.txt",
+    "wheelhouse",
+    "models\whisper-small",
+    "SHA256SUMS.csv"
+)
+foreach ($item in $required) {
+    if (-not (Test-Path -LiteralPath (Join-Path $bundle.Path $item))) {
+        throw "Offline bundle is incomplete: missing $item"
+    }
+}
+
+$rows = Import-Csv -LiteralPath (Join-Path $bundle.Path "SHA256SUMS.csv")
+foreach ($row in $rows) {
+    $path = Join-Path $bundle.Path $row.Path
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "Manifest file is missing: $($row.Path)"
+    }
+    $actual = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash
+    if ($actual -ne $row.SHA256) {
+        throw "Hash verification failed: $($row.Path)"
+    }
+}
+Write-Host "Offline bundle verified: $($rows.Count) files"


### PR DESCRIPTION
## Purpose

Create a practical offline KinaBot research path in response to prospective UK university use and record it as a Purdue Online Data Science milestone without claiming institutional approval.

## What changed

- school-assigned participant IDs such as 001; no email or SMTP
- study-secret HMAC pseudonyms; raw participant IDs are not persisted
- mandatory local faster-whisper model path with no silent model download
- OpenAI disabled at code level in offline mode
- local SQLite, longitudinal history, and de-identified export
- offline dependency manifest, installer, launcher, bundle builder, SHA-256 manifest, and verifier
- quick start, acceptance test, UK/EU data-protection readiness, and university milestone documentation
- added offline-specific risks, validation status, changelog, decision log, and project-evolution record

## Validation

- Python compilation passed
- 24 automated tests passed
- school ID 001 AppTest login passed
- verified SQLite stores no email or raw 001 value
- all four PowerShell delivery scripts parsed successfully
- Streamlit offline health endpoint returned 200 ok

## Remaining packaging dependency

The approved Windows wheelhouse and faster-whisper small model must be acquired on an institution-approved network and added to the generated delivery bundle. The current corporate network blocked the official model download because its TLS inspection CA was unavailable; SSL verification was not bypassed.

## Compliance boundary

The engineering controls support university privacy and security review. They do not themselves establish UK GDPR/EU GDPR compliance, ethics approval, clinical validity, or institutional endorsement.