### PR TITLE
Build KinaBot product learning archive

### DIFF
--- a/aoi_kinabot_app/CHANGELOG.md
+++ b/aoi_kinabot_app/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2026-08-06 · Dated learning case library
+
+- Established a publication standard and reusable template for meaningful,
+  evidence-linked product learning cases.
+- Published the first case on redesigning an online product for offline
+  university research, including alternatives, failures, corrections, tests,
+  social context, student work, unresolved risks, and claims boundaries.
+- Linked the case library to feedback, engineering learning, the open knowledge
+  center, and planned data-science teaching material.
+- Expanded the library into a product learning archive with a complete journey
+  timeline, commit/PR evidence map, globally reusable open curriculum, and
+  September 2026 white paper preparation roadmap.
+- Separated collaborative exploration from the independently developed
+  Aoi-maintained application so contributor credit and current product
+  responsibility remain visible.
+
 ## 2026-08-05 · Offline university research mode
 
 - Added school-assigned participant IDs without email collection or SMTP.
@@ -8,8 +24,8 @@
 - Enforced local Whisper model paths and disabled OpenAI in offline mode.
 - Added offline-only dependencies, installation, launch, bundle-build, checksum,
   verification, quick-start, and acceptance-test materials.
-- Added UK/EU data-protection readiness and a university/Purdue data-science
-  milestone record without claiming institutional approval or legal compliance.
+- Added UK/EU data-protection readiness and a reusable learning record without
+  claiming institutional approval or legal compliance.
 
 ## 2026-08-03 · 30-day pattern experience
 

--- a/aoi_kinabot_app/docs/DECISION-LOG.md
+++ b/aoi_kinabot_app/docs/DECISION-LOG.md
@@ -23,6 +23,7 @@ considered.
 | 2026-08-03 | Introduce a low-pressure 30-day pattern experience with one recommended daily reflection | Make the value understandable before asking for repeated use; keep extra check-ins optional and avoid streak penalties |
 | 2026-08-05 | Establish validation gates, an active AI risk register, and evidence-defined impact metrics | Make future releases, pilots, public claims, and independent evaluation follow one auditable human-centered framework |
 | 2026-08-05 | Create an offline university research mode with school IDs, study-secret HMAC pseudonyms, and mandatory local transcription | Support privacy-sensitive UK and university research without email, cloud scoring, or silent model downloads |
+| 2026-08-06 | Publish meaningful changes as dated, evidence-linked learning cases | Preserve first-hand failures, tradeoffs, verification, and social context as reusable education rather than retrospective promotion |
 
 ## Template for Future Decisions
 

--- a/aoi_kinabot_app/docs/ENGINEERING-LEARNINGS.md
+++ b/aoi_kinabot_app/docs/ENGINEERING-LEARNINGS.md
@@ -110,3 +110,14 @@ Local syntax checks are necessary but insufficient. Validate:
 API credentials belong in AWS Secrets Manager or local environment variables.
 Logs and diagnostic commands should be designed so exceptions cannot echo a
 secret. If a key appears in terminal output, revoke and rotate it.
+
+## 11. Offline Is A System Property, Not A Label
+
+Local scoring alone does not make a system offline. Identity, dependency
+installation, model loading, telemetry, optional APIs, network binding, update
+behavior, and acceptance testing must all be examined.
+
+Short school IDs also show why context matters: an ordinary hash can be
+enumerated, while a study-secret HMAC creates a stronger pseudonym but adds
+secret backup and recovery responsibilities. See the dated case study,
+[From Online Product to Offline University Research](learning-cases/aoi-maintained-product/2026-08-05-offline-university-research.md).

--- a/aoi_kinabot_app/docs/PROJECT-EVOLUTION.md
+++ b/aoi_kinabot_app/docs/PROJECT-EVOLUTION.md
@@ -8,8 +8,11 @@ effectiveness.
 ## 1. Origin and Early Public Exploration
 
 KinaBot's product history traces its origin to the name Kizuna in May 2025.
-The currently available public Git record begins on November 28, 2025, with
-Aoi Minamoto's initial repository work and open-source V1 publication.
+The repository's complete public Git history across preserved refs begins on
+November 28, 2025, with Aoi Minamoto's initial repository work and open-source
+V1 publication. The current maintained branch contains a later reconstructed
+history beginning in June 2026, so provenance checks should inspect all refs
+rather than the current branch alone.
 
 The early repository explored speech-derived cognitive-insight concepts,
 Streamlit delivery, privacy and medical disclaimers, documentation, automated
@@ -130,6 +133,6 @@ school-assigned IDs, stores study-secret HMAC pseudonyms, disables SMTP and
 OpenAI, and requires an existing local speech model so the application cannot
 silently download one. The work includes local installation and launch scripts,
 checksum-based bundle controls, an offline acceptance procedure, UK/EU
-data-protection readiness documentation, and a Purdue Online Data Science
+data-protection readiness documentation, and a university data science
 milestone record. Institutional adoption or approval must be documented
 separately if it occurs.

--- a/aoi_kinabot_app/docs/README.md
+++ b/aoi_kinabot_app/docs/README.md
@@ -21,10 +21,11 @@ what a voice sample can prove.
 - [UK/EU Data-Protection Readiness](UK-EU-DATA-PROTECTION-READINESS.md)
 - [Decision Log](DECISION-LOG.md)
 - [Project Evolution and Continuing Contribution](PROJECT-EVOLUTION.md)
+- [Dated Learning Case Library](learning-cases/README.md)
 - [Public User Feedback](feedback/README.md)
 - [Eight Feature Definitions](methodology/METRIC-DEFINITIONS.md)
 - [Mobile-First Results Architecture](ux/MOBILE-FIRST-RESULTS.md)
-- [Purdue Data Science Teaching Case](education/PURDUE-DATA-SCIENCE-CASE-STUDY.md)
+- [Product Learning Archive](learning-cases/README.md)
 - [University Offline Research Milestone](education/UNIVERSITY-OFFLINE-RESEARCH-MILESTONE.md)
 
 Technical references remain in the application root:

--- a/aoi_kinabot_app/docs/education/UNIVERSITY-OFFLINE-RESEARCH-MILESTONE.md
+++ b/aoi_kinabot_app/docs/education/UNIVERSITY-OFFLINE-RESEARCH-MILESTONE.md
@@ -5,12 +5,11 @@ Date established: 2026-08-05
 ## Milestone Purpose
 
 This milestone records the development of a reproducible offline research mode
-for two educational and research contexts:
+for two general learning and research contexts:
 
 1. a prospective UK university researcher who requested local/offline KinaBot
    use; and
-2. the Purdue University Online Data Science educational record planned for the
-   fall academic term.
+2. reusable practical learning material for studying data-product decisions.
 
 No university endorsement, formal partnership, ethics approval, or deployment
 is implied unless supported by a separate institutional document.

--- a/aoi_kinabot_app/docs/feedback/README.md
+++ b/aoi_kinabot_app/docs/feedback/README.md
@@ -18,6 +18,12 @@ Public records must:
 Feedback is evidence of a product-design input. It is not proof of clinical
 validity, user impact, adoption, or causation.
 
+When feedback leads to a material, generalizable change across architecture,
+privacy, safety, accessibility, validation, or institutional context, preserve
+the feedback record here and create a linked dated case in the
+[Learning Case Library](../learning-cases/README.md). The feedback record keeps
+the input traceable; the learning case explains the broader decision and lesson.
+
 ## Record Template
 
 ```markdown

--- a/aoi_kinabot_app/docs/learning-cases/EVIDENCE-MAP.md
+++ b/aoi_kinabot_app/docs/learning-cases/EVIDENCE-MAP.md
@@ -1,0 +1,33 @@
+# KinaBot Learning Evidence Map
+
+This map connects educational conclusions to inspectable public records. A
+commit proves that work was recorded at a point in the repository history; it
+does not by itself prove adoption, effectiveness, originality in law, or
+field-wide significance.
+
+| Learning turn | Code or commit record | Review or supporting record |
+|---|---|---|
+| Initial open-source foundation | [`b8b8f20`](https://github.com/usekina/kina/commit/b8b8f20), [`0ecc5f7`](https://github.com/usekina/kina/commit/0ecc5f7) | Repository history and [Project Evolution](../PROJECT-EVOLUTION.md) |
+| Aoi-maintained new application boundary | [`8a92fd8`](https://github.com/usekina/kina/commit/8a92fd8) | [Ownership and Maintainership](../../OWNERSHIP-AND-MAINTAINERSHIP.md) |
+| Pilot, access, and score design | [`ffb6ddf`](https://github.com/usekina/kina/commit/ffb6ddf), [`9c95eaa`](https://github.com/usekina/kina/commit/9c95eaa), [`2c4f46d`](https://github.com/usekina/kina/commit/2c4f46d) | [Scoring Methodology](../../SCORING-METHODOLOGY.md) |
+| Deterministic implementation and verification | [`e1959b9`](https://github.com/usekina/kina/commit/e1959b9), [`94c305a`](https://github.com/usekina/kina/commit/94c305a), [`8c2f21a`](https://github.com/usekina/kina/commit/8c2f21a) | Application tests and [Metric Definitions](../methodology/METRIC-DEFINITIONS.md) |
+| Ephemeral audio and transcription | [`c36efb1`](https://github.com/usekina/kina/commit/c36efb1), [`20ad4dd`](https://github.com/usekina/kina/commit/20ad4dd), [`6458d60`](https://github.com/usekina/kina/commit/6458d60) | [Engineering Learnings](../ENGINEERING-LEARNINGS.md) |
+| Multilingual NLP | [`3798d80`](https://github.com/usekina/kina/commit/3798d80) | [PR #16](https://github.com/usekina/kina/pull/16) |
+| Timestamp-based acoustic analysis | [`83ffc9b`](https://github.com/usekina/kina/commit/83ffc9b) | [PR #17](https://github.com/usekina/kina/pull/17) |
+| Deployment and HTTPS | [`2c1725b`](https://github.com/usekina/kina/commit/2c1725b), [`6e626bc`](https://github.com/usekina/kina/commit/6e626bc) | [PR #19](https://github.com/usekina/kina/pull/19) |
+| Localized results and research export | [`5a3e350`](https://github.com/usekina/kina/commit/5a3e350) | [PR #20](https://github.com/usekina/kina/pull/20) |
+| Profiles, repeated sessions, and local dates | [`cdf45cd`](https://github.com/usekina/kina/commit/cdf45cd), [`fcafb4c`](https://github.com/usekina/kina/commit/fcafb4c), [`434c563`](https://github.com/usekina/kina/commit/434c563) | [Decision Log](../DECISION-LOG.md) |
+| Recording convenience and reliability reversal | [`8f10fb7`](https://github.com/usekina/kina/commit/8f10fb7), [`5ed90b5`](https://github.com/usekina/kina/commit/5ed90b5) | [PR #23](https://github.com/usekina/kina/pull/23) |
+| Open knowledge center | [`341acef`](https://github.com/usekina/kina/commit/341acef) | [PR #22](https://github.com/usekina/kina/pull/22) |
+| Mobile trends from feedback | [`484fd80`](https://github.com/usekina/kina/commit/484fd80), [`56cf22d`](https://github.com/usekina/kina/commit/56cf22d) | [PR #27](https://github.com/usekina/kina/pull/27) and [feedback record](../feedback/2026-08-mobile-results-navigation.md) |
+| Dignity-first design and validation governance | [`f6f3134`](https://github.com/usekina/kina/commit/f6f3134), [`c99dcd1`](https://github.com/usekina/kina/commit/c99dcd1) | [PR #28](https://github.com/usekina/kina/pull/28), [Risk Register](../AI-RISK-REGISTER.md), and [Validation Plan](../VALIDATION-PLAN.md) |
+| Offline research mode | [`5a23963`](https://github.com/usekina/kina/commit/5a23963) | [PR #29](https://github.com/usekina/kina/pull/29) and [Offline Research Guide](../OFFLINE-RESEARCH-GUIDE.md) |
+
+## Authorship Boundary
+
+The repository-wide history contains identifiable commits by Aoi Minamoto,
+Yuan Chen, and Irene Li. The current Git history under `aoi_kinabot_app/`
+attributes its commits to Aoi Minamoto. This path-specific observation preserves
+historical collaboration while making the maintained new application's
+contribution record inspectable. Legal inventorship and broader impact require
+separate analysis and evidence.

--- a/aoi_kinabot_app/docs/learning-cases/JOURNEY-TIMELINE.md
+++ b/aoi_kinabot_app/docs/learning-cases/JOURNEY-TIMELINE.md
@@ -1,0 +1,119 @@
+# KinaBot Journey Timeline
+
+This timeline preserves the meaningful steps in KinaBot's development, not only
+the largest releases. It distinguishes founder provenance, repository evidence,
+implemented behavior, and future goals.
+
+## 2025-05 · Founder-Reported MVP Launch
+
+- The maintained founder record traces the product idea and MVP launch to
+  **Kizuna** in May 2025.
+- **Evidence type:** founder provenance. This date is not established by the
+  preserved Git metadata and needs a contemporaneous artifact if
+  used as formal evidence.
+- **Takeaway:** preserve the human origin story, but label the source honestly.
+
+## 2025-11-28 to 2026-01-09 · Collaborative Open-Source Exploration
+
+- Aoi's preserved public Git history begins on 2025-11-28 with the initial
+  repository and open-source V1 work.
+- Irene Li contributed code and run documentation in December 2025.
+- Yuan Chen contributed tests, CI, PDF and scoring experiments, dependency and
+  quality improvements, signal documentation, and frontend/backend structure
+  from December 2025 into January 2026.
+- Aoi continued product direction, integration, documentation, privacy,
+  security, and repository maintenance during this phase.
+- **Takeaway:** complete provenance requires inspecting all refs and crediting
+  contributors by the work actually recorded.
+
+## 2026-06-11 · Aoi-Maintained New Product Foundation
+
+- `aoi_kinabot_app/` established a new version and independent technical
+  direction developed and maintained by Aoi, while the original area continued
+  to preserve all identifiable historical contributors.
+- Pilot, data-access, feature-score, and implementation plans were written
+  before the maintained application was assembled.
+- SQLite helpers, deterministic scoring, local verification, Streamlit flow,
+  temporary audio procedures, upload, and transcription followed.
+- **Takeaway:** a credible product boundary is made from governance, method,
+  code, and tests together.
+
+## 2026-07-28 · Multilingual, Longitudinal, and Deployable
+
+- English, Japanese, and Chinese adapters replaced an English-only assumption.
+- Timestamp-based pause and voiced-duration analysis strengthened acoustic
+  measurement.
+- Ownership, methodology, and impact boundaries were documented.
+- AWS staging, HTTPS delivery, localized results, and research export moved the
+  work toward an operational pilot platform.
+- Anonymous wellness communication was separated from deterministic scoring.
+- Returning profiles and repeated sessions introduced longitudinal use.
+- **Takeaway:** globalization, privacy, reproducibility, and deployment must
+  evolve together.
+
+## 2026-07-29 · First-Session Value and Local-Time Meaning
+
+- Direct recording and a first-session expression snapshot reduced apparent
+  friction and made the first result easier to understand.
+- CloudFront configuration was corrected for a dynamic application.
+- UTC event time was paired with the user's local calendar day and IANA
+  timezone.
+- **Takeaway:** infrastructure and time semantics directly shape user trust.
+
+## 2026-07-30 · Open Knowledge as a Product Output
+
+- A public knowledge center began sharing definitions, decisions, and verified
+  engineering lessons.
+- **Takeaway:** documentation is not an appendix when transparency is part of
+  the product promise.
+
+## 2026-07-31 · Reliability Before Novelty
+
+- Direct browser recording was withdrawn from the primary flow when real
+  runtime reliability was not good enough; upload became the dependable path.
+- A warmer multilingual landing experience and clearer wellness framing were
+  added without expanding the scientific claim.
+- **Takeaway:** removing an unreliable feature can be a meaningful advance.
+
+## 2026-08-02 · Feedback Became Data-Product Architecture
+
+- Mobile feedback led to Today/Trends navigation, compact current results,
+  one-feature trend views, and accessible scoring explanations.
+- The observation, implementation, and learning record were linked publicly.
+- **Takeaway:** feedback creates value when it becomes a testable requirement
+  and an auditable decision.
+
+## 2026-08-03 to 2026-08-05 · Dignity and Evidence Governance
+
+- The 30-day experience emphasized one recommended reflection, optional extra
+  check-ins, and no streak penalty.
+- Dignity-first language and family-centered boundaries were consolidated.
+- Validation gates, an AI risk register, impact metrics, and a project-evolution
+  record were established.
+- **Takeaway:** human-centered values need release gates and evidence rules.
+
+## 2026-08-05 · Offline Research Context
+
+- A research mode removed email and SMTP, accepted school-assigned IDs, used
+  study-secret HMAC pseudonyms, disabled OpenAI, required a local speech model,
+  and added bundle integrity and acceptance procedures.
+- **Takeaway:** offline operation is a system property, not a feature label.
+
+## 2026-08-05 onward · Learning Archive
+
+- Meaningful changes are now converted into dated cases with context,
+  alternatives, failures, verification, reflection, and claims boundaries.
+- **Takeaway:** continuous contribution becomes more useful when others can
+  inspect and learn from the reasoning, including mistakes and uncertainty.
+
+## Evidence Frontier
+
+The next milestones are not yet achievements: real pilots, representative user
+results, independent validation, institutional adoption, publications,
+citations, and external recognition. They should be added only after the
+corresponding evidence exists.
+
+For detailed cases, return to the [Product Learning Archive](README.md). For the
+broader factual record, see [Project Evolution](../PROJECT-EVOLUTION.md), the
+[Decision Log](../DECISION-LOG.md), and the application
+[Changelog](../../CHANGELOG.md).

--- a/aoi_kinabot_app/docs/learning-cases/OPEN-CURRICULUM.md
+++ b/aoi_kinabot_app/docs/learning-cases/OPEN-CURRICULUM.md
@@ -1,0 +1,108 @@
+# Open Curriculum: Building Human-Centered AI Products from Real Decisions
+
+This curriculum turns KinaBot's inspectable development history into practical
+learning for students, independent builders, researchers, engineers, designers,
+and product leaders anywhere in the world. It is not tied to one institution.
+Reuse remains subject to the repository's license and attribution terms.
+
+## Learning Promise
+
+After completing the sequence, learners should be able to connect a human need
+to a product decision, code change, validation method, evidence boundary, and
+responsible public claim.
+
+## Module 1 · Provenance and Independent Direction
+
+**Case:** [Origin, Collaboration, and an Independent Product Boundary](collaborative-exploration/2025-05-to-2026-06-origin-collaboration-boundary.md)
+
+**Learn:** distinguish collaboration, maintainership, ownership, authorship,
+and inventorship; preserve history while defining a new maintained direction.
+
+**Practice:** inspect path-specific Git authorship and draft a contribution
+boundary that credits every contributor without overstating exclusivity.
+
+## Module 2 · Claims Must Shape Architecture
+
+**Case:** [Observable Features, Not Diagnosis](aoi-maintained-product/2026-06-11-observable-features-not-diagnosis.md)
+
+**Learn:** translate a non-diagnostic claim boundary into data models, scoring,
+language, retention, and tests.
+
+**Practice:** redesign an unsupported composite score as transparent observable
+features and identify the validation still required.
+
+## Module 3 · Multilingual AI Is Method Design
+
+**Case:** [Multilingual Design Is More Than Translation](aoi-maintained-product/2026-07-28-multilingual-longitudinal-design.md)
+
+**Learn:** recognize how segmentation, timing, grammar, culture, and unequal
+evaluation data affect multilingual systems.
+
+**Practice:** create a language-assumption register and cross-language test
+matrix for one proposed feature.
+
+## Module 4 · Reliability Is Human-Centered Design
+
+**Case:** [Removing a Feature When Reliability Was Not Good Enough](aoi-maintained-product/2026-07-29-to-31-recording-reliability.md)
+
+**Learn:** treat retries, lost input, device differences, and operational
+failures as user experience and dignity issues.
+
+**Practice:** define evidence-based release and rollback criteria for browser
+media capture.
+
+## Module 5 · Feedback to Data-Product Decision
+
+**Case:** [From User Feedback to a Data Product](aoi-maintained-product/2026-08-02-feedback-to-data-product.md)
+
+**Learn:** separate observation from proposed solution and connect qualitative
+feedback to navigation, data presentation, privacy, and measurement.
+
+**Practice:** write a trace from anonymized feedback through requirement,
+implementation, test, and unresolved outcome metric.
+
+## Module 6 · Dignity, Governance, and Evidence
+
+**Case:** [Dignity First](aoi-maintained-product/2026-08-05-dignity-first-validation.md)
+
+**Learn:** turn values into interface choices, access rules, risk records,
+impact metrics, validation gates, and claims discipline.
+
+**Practice:** audit a wellness feature for coercion, overclaiming, caregiver
+power, accessibility, and unmeasured harm.
+
+## Module 7 · Context Changes the System
+
+**Case:** [From Online Product to Offline University Research](aoi-maintained-product/2026-08-05-offline-university-research.md)
+
+**Learn:** understand offline operation as identity, model, dependency,
+network, storage, pseudonymisation, and acceptance-test design.
+
+**Practice:** threat-model short participant IDs and design a reproducible
+offline handoff without disabling security checks.
+
+## Capstone · An Evidence-Bounded Product Change
+
+Learners select one real product problem and submit:
+
+1. an anonymized observation and context;
+2. competing human and technical requirements;
+3. alternatives and a justified decision;
+4. a small implementation or architecture change;
+5. tests and negative results;
+6. a risk and claims-boundary update; and
+7. a dated learning case linked to verifiable evidence.
+
+Assessment should reward traceability, care, correction, and honest uncertainty—not
+feature count or promotional language.
+
+## Teaching Notes
+
+- Cases can be taught independently or as a seven-module sequence.
+- Ask learners to inspect the [Evidence Map](EVIDENCE-MAP.md), not merely accept
+  the narrative.
+- Never use real participant data in a classroom repository.
+- Separate a working demonstration from usability, clinical, and social-impact
+  evidence.
+- Invite critique. A learning archive should improve when independent evidence
+  challenges its conclusions.

--- a/aoi_kinabot_app/docs/learning-cases/README.md
+++ b/aoi_kinabot_app/docs/learning-cases/README.md
@@ -1,0 +1,138 @@
+# KinaBot Product Learning Archive
+
+This library turns meaningful product changes into dated, first-hand educational
+case studies. It is intended for students, researchers, open-source builders,
+and responsible-AI practitioners who need to understand not only what changed,
+but why the surrounding human, institutional, legal, and technical environment
+made that change necessary.
+
+## Publication Standard
+
+A change belongs here only when it teaches a reusable lesson and has enough
+primary evidence to distinguish observation from hindsight. Good candidates
+include:
+
+- a new user or institutional environment that changes system requirements;
+- a privacy, safety, accessibility, fairness, or reliability conflict;
+- a failed assumption or implementation that materially changes the design;
+- a decision that creates measurable tradeoffs;
+- a validation result that confirms or overturns a design belief; or
+- an external request that leads to a generalizable engineering method.
+
+Routine copy edits, dependency bumps, and minor refactors do not become cases
+unless they reveal a broader lesson.
+
+## Required Case Structure
+
+Every case should include:
+
+1. date and status;
+2. anonymized source and context;
+3. prior system and triggering event;
+4. competing technical, human, institutional, and legal requirements;
+5. alternatives considered and the selected decision;
+6. implementation and data flow;
+7. failure, correction, or changed assumption;
+8. verification and unresolved evidence;
+9. social and educational meaning;
+10. student exercises and discussion questions; and
+11. evidence links and claims boundaries.
+
+## Evidence Rules
+
+- Link issues, commits, pull requests, tests, and dated documents.
+- Paraphrase external feedback unless quotation permission is recorded.
+- Do not expose personal, health, research, employment, or confidential data.
+- Distinguish a prospective inquiry from adoption or institutional approval.
+- Preserve negative and inconclusive evidence.
+- Do not claim legal compliance, clinical validity, educational impact, or
+field-wide significance without independent support.
+- Correct retrospective records transparently rather than silently rewriting
+  history.
+
+## How to Read This Archive
+
+The cases follow product turning points, not a marketing release calendar. Each
+case separates three things:
+
+- **contemporaneous evidence**: commits, pull requests, tests, and dated notes;
+- **maintainer reflection**: what Aoi learned from making and reviewing the
+  change; and
+- **open evidence**: what still requires users, institutions, researchers, or
+  independent evaluators.
+
+First-person reflections are retrospective interpretations of the linked
+record. They should be updated when stronger evidence changes the lesson.
+
+## Learn or Verify
+
+- Use the [Open Curriculum](OPEN-CURRICULUM.md) to teach, self-study, or run a
+  product-team workshop from the cases.
+- Use the [Evidence Map](EVIDENCE-MAP.md) to trace lessons to commits, pull
+  requests, code, tests, and governing documents.
+- Use the [Journey Timeline](JOURNEY-TIMELINE.md) to see the complete sequence
+  without turning every small change into a separate case.
+- Use the [White Paper Roadmap](WHITEPAPER-ROADMAP.md) to prepare the September
+  2026 publication without treating planned evidence as completed evidence.
+
+## Case Template
+
+```markdown
+# Case title
+
+Date:
+Status:
+Source:
+Context:
+Public-record basis:
+
+## Background
+## Trigger
+## Competing Requirements
+## Alternatives Considered
+## Decision
+## Implementation
+## What Failed or Changed
+## Verification
+## Remaining Risks and Evidence Gaps
+## Social and Human-Centered Meaning
+## Student Exercise
+## Discussion Questions
+## Evidence Links
+## Reuse and Claims Boundary
+```
+
+## Two Sources of Learning
+
+### Collaborative Exploration
+
+The original project area preserves work by all identifiable contributors. Its
+lessons concern collaboration, attribution, exploratory prototypes, and the
+decision to establish a clearer product boundary.
+
+- [2025-05 to 2026-06 · Origin, Collaboration, and an Independent Product Boundary](collaborative-exploration/2025-05-to-2026-06-origin-collaboration-boundary.md)
+
+### Aoi-Maintained Product
+
+The cases below concern the new `aoi_kinabot_app/` direction. The current Git
+history for this path attributes its commits to Aoi Minamoto. These cases record
+Aoi's product, engineering, privacy, reliability, and governance learning.
+
+Start with the [Journey Timeline](JOURNEY-TIMELINE.md) for a compact record of
+all meaningful milestones. The cases below examine the largest learning turns.
+
+- [2026-06-11 · Replacing Diagnostic-Like Scores with Observable Features](aoi-maintained-product/2026-06-11-observable-features-not-diagnosis.md)
+- [2026-07-28 · Multilingual Design Is More Than Translation](aoi-maintained-product/2026-07-28-multilingual-longitudinal-design.md)
+- [2026-07-29 to 2026-07-31 · Removing a Feature When Reliability Was Not Good Enough](aoi-maintained-product/2026-07-29-to-31-recording-reliability.md)
+- [2026-08-02 · From User Feedback to a Data Product](aoi-maintained-product/2026-08-02-feedback-to-data-product.md)
+- [2026-08-05 · Dignity First: Changing Product Success and Evidence Standards](aoi-maintained-product/2026-08-05-dignity-first-validation.md)
+- [2026-08-05 · From Online Product to Offline University Research](aoi-maintained-product/2026-08-05-offline-university-research.md)
+
+## The Next Cases Must Be Earned
+
+Real-world pilots, independent validation, institutional adoption, published
+research, citations, and demonstrated benefit are not current achievements just
+because they are desired. They become new cases only after dated third-party
+evidence exists. Until then, they remain validation goals in
+[`VALIDATION-PLAN.md`](../VALIDATION-PLAN.md) and
+[`IMPACT-METRICS.md`](../IMPACT-METRICS.md).

--- a/aoi_kinabot_app/docs/learning-cases/WHITEPAPER-ROADMAP.md
+++ b/aoi_kinabot_app/docs/learning-cases/WHITEPAPER-ROADMAP.md
@@ -1,0 +1,63 @@
+# White Paper Publication Roadmap
+
+**Target:** September 2026
+
+**Working purpose:** transform the public learning archive into an evidence-led
+white paper for global AI product builders, educators, and researchers.
+
+## Proposed Thesis
+
+Human-centered AI product development becomes more credible when provenance,
+technical decisions, failures, privacy boundaries, validation gaps, and
+maintainer reflections remain traceable to inspectable evidence.
+
+## Proposed Structure
+
+1. Product origin and collaborative exploration
+2. Establishing an independently maintained product boundary
+3. Replacing diagnostic-like claims with observable features
+4. Multilingual and longitudinal system design
+5. Reliability-driven reversal and operational learning
+6. Feedback as data-product architecture
+7. Dignity-first design and responsible evidence governance
+8. Offline research as contextual system redesign
+9. An open curriculum for reusable product learning
+10. Limitations, independent evaluation needs, and future research
+
+## Publication Evidence Checklist
+
+- Freeze a cited repository tag and record its commit SHA.
+- Verify every factual date against all relevant Git refs and external records.
+- Obtain or archive contemporaneous evidence for the May 2025 MVP launch.
+- Confirm contributor names, roles, quotations, and permissions.
+- Export PR, test, release, and decision references into a stable bibliography.
+- Separate implemented behavior from planned work and external inquiry from
+  adoption.
+- Add measured pilot or usability results only with consent and documented
+  methods.
+- Invite independent technical, privacy, research-method, and editorial review.
+- Record conflicts of interest, funding, AI assistance, limitations, and
+  corrections.
+- Choose a publication venue, identifier, versioning policy, and repository
+  archive appropriate to the intended audience.
+
+## Evidence Gates Before Publication
+
+The white paper should not claim clinical validity, legal compliance,
+institutional endorsement, educational impact, or field-wide significance
+unless independent evidence supports that exact claim. Git history supports
+chronology and contribution; it is not a substitute for outcome evidence.
+
+## Source Package
+
+- [Journey Timeline](JOURNEY-TIMELINE.md)
+- [Evidence Map](EVIDENCE-MAP.md)
+- [Open Curriculum](OPEN-CURRICULUM.md)
+- [Collaborative Exploration](collaborative-exploration/README.md)
+- [Aoi-Maintained Product](aoi-maintained-product/README.md)
+- [Project Evolution](../PROJECT-EVOLUTION.md)
+- [Validation Plan](../VALIDATION-PLAN.md)
+- [Impact Metrics](../IMPACT-METRICS.md)
+
+This roadmap is a preparation record, not a claim that the white paper has
+already been published or independently reviewed.

--- a/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-06-11-observable-features-not-diagnosis.md
+++ b/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-06-11-observable-features-not-diagnosis.md
@@ -1,0 +1,70 @@
+# Replacing Diagnostic-Like Scores with Observable Features
+
+**Date:** 2026-06-11
+
+**Status:** Implemented product boundary
+
+**Source:** V1 plans, scoring design, implementation, and tests
+
+## Background and Problem
+
+Speech technology can produce numbers that look authoritative before their
+meaning is scientifically established. Early exploratory concepts included
+composite or risk-style ideas. For a human-centered wellness product, those
+presentations could cause a person to interpret a short voice sample as a
+judgment about intelligence, age, disease, or personal worth.
+
+The engineering challenge was not only to add a disclaimer. The system needed
+an architecture whose outputs matched the modest claim it could responsibly
+make.
+
+## Alternatives Considered
+
+- Keep an attractive overall score and explain its limitations.
+- Produce disease or cognitive-risk estimates while labeling them
+  experimental.
+- Use an LLM to infer a holistic condition from audio or transcript.
+- Present separate, versioned speech and language features for reflection over
+  time.
+
+## Decision and Implementation
+
+Aoi selected the fourth approach. The maintained V1 separated observable
+features, documented their transformations, versioned the scoring behavior,
+and excluded cognitive age, dementia risk, diagnosis, and treatment advice.
+Temporary audio handling, consent, data access, pilot planning, database
+helpers, and tests were developed with that boundary.
+
+## Maintainer Reflection
+
+> I learned that responsible AI is not achieved by placing a warning beneath an
+> overreaching score. The claim boundary has to shape the data model, scoring
+> functions, interface language, retention policy, and tests. A less dramatic
+> result can be more useful when a person can understand what it does and does
+> not mean.
+
+## Reusable Knowledge
+
+- A precise feature is preferable to an unsupported composite label.
+- Interface tone cannot repair a method that exceeds its evidence.
+- Store raw measurements and method versions so later changes remain auditable.
+- Treat non-diagnostic positioning as an engineering constraint, not marketing
+  copy.
+
+## Verification and Open Evidence
+
+The 2026-06-11 sequence includes the feature-score design (`2c4f46d`), local
+verification helpers (`e1959b9`), scoring functions (`94c305a`), and application
+skeleton (`8c2f21a`). See
+[`SCORING-METHODOLOGY.md`](../../../SCORING-METHODOLOGY.md) and
+[`METRIC-DEFINITIONS.md`](../../methodology/METRIC-DEFINITIONS.md).
+
+These records show a reproducible design decision. They do not establish that
+the features are clinical biomarkers or that they predict health outcomes.
+
+## Discussion Questions
+
+1. When does a numerical score become a health claim?
+2. Can a disclaimer compensate for a misleading product architecture?
+3. What evidence would be required before adding a clinically meaningful
+   interpretation?

--- a/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-07-28-multilingual-longitudinal-design.md
+++ b/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-07-28-multilingual-longitudinal-design.md
@@ -1,0 +1,72 @@
+# Multilingual Design Is More Than Translation
+
+**Date:** 2026-07-28
+
+**Status:** Implemented in the maintained application
+
+**Source:** Multilingual NLP, acoustic-feature, localization, and export work
+
+## Trigger
+
+A global speech-reflection product cannot assume that rules designed for
+English remain meaningful in Japanese and Chinese. Word segmentation, grammar,
+pace units, script, examples, and interface expectations differ. At the same
+time, repeated sessions require stable versions so a later result can be
+interpreted against the method used at that time.
+
+## Competing Requirements
+
+- Give users an experience in the language they speak.
+- Keep calculations deterministic and inspectable.
+- Avoid sending sensitive audio, transcripts, names, or email to a generative
+  model.
+- Preserve comparability without pretending every language is structurally
+  identical.
+
+## Decision
+
+KinaBot implemented language-specific adapters for English, Japanese, and
+Chinese; local transcription and feature calculation; timestamp-based voiced
+duration and pauses; versioned feature records; localized explanations; and a
+research export separated from direct identity.
+
+The optional generative layer was limited to evidence-bounded communication
+from minimized score trends and curated actions. It did not become the scoring
+authority.
+
+## Maintainer Reflection
+
+> I learned that multilingual inclusion is architectural work. Translating
+> labels is the visible last step; the deeper work is deciding what a token, a
+> pause, a pace measure, and a fair comparison mean in each language. I also
+> learned to keep generative fluency separate from measurement authority.
+
+## Reusable Knowledge
+
+- Internationalization and methodological localization are different tasks.
+- Document language-specific assumptions and validation separately.
+- Keep deterministic measurement independent from generated explanations.
+- Version research-relevant behavior before collecting longitudinal data.
+- Do not interpret equal-looking numbers as automatically equivalent across
+  languages.
+
+## Evidence and Limits
+
+Public evidence includes PRs
+[#16](https://github.com/usekina/kina/pull/16),
+[#17](https://github.com/usekina/kina/pull/17), and
+[#20](https://github.com/usekina/kina/pull/20), plus
+[`ARCHITECTURE.md`](../../../ARCHITECTURE.md) and
+[`ENGINEERING-LEARNINGS.md`](../../ENGINEERING-LEARNINGS.md).
+
+Implementation in three languages is not evidence of cross-language validity,
+measurement invariance, accessibility for all speakers, or equal performance
+across accents and conditions. Those require representative evaluation.
+
+## Discussion Questions
+
+1. Which speech features can be shared across languages, and which require
+   language-specific definitions?
+2. How should a team report cross-language performance without hiding unequal
+   sample sizes?
+3. Where can generative AI add value without controlling the measurement?

--- a/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-07-29-to-31-recording-reliability.md
+++ b/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-07-29-to-31-recording-reliability.md
@@ -1,0 +1,57 @@
+# Removing a Feature When Reliability Was Not Good Enough
+
+**Period:** 2026-07-29 to 2026-07-31
+
+**Status:** Implemented correction
+
+**Source:** Recording, deployment, and upload-flow commits
+
+## Background
+
+Direct browser recording appeared to be the most human-centered mobile path:
+it removed the need to find a separate recorder and locate an audio file. The
+feature was added with upload as a fallback, and HTTPS infrastructure was used
+because mobile microphone access requires a secure context.
+
+## What Changed
+
+Real runtime behavior did not meet the reliability standard across the intended
+environment. A feature that looked simpler in the interface created uncertainty
+when browser, permission, format, and deployment behavior varied.
+
+On 2026-07-31, the maintained flow changed to reliable upload-only audio rather
+than keeping an unstable primary path merely because it was more impressive.
+
+## Maintainer Reflection
+
+> I learned that human-centered design is not the same as minimizing the number
+> of taps in a mock-up. Reliability is part of dignity: a person should not be
+> asked to repeat a sensitive reflection because the product chose novelty over
+> dependable behavior. Removing my own feature was progress when the evidence
+> showed it was not ready.
+
+## Reusable Knowledge
+
+- Test media capture on the real browser, device, HTTPS route, and deployment.
+- Count failed and repeated attempts as user harm, not only technical errors.
+- Preserve a dependable fallback before promoting a more convenient path.
+- A public reversal can be stronger engineering evidence than silently keeping
+  a weak feature.
+
+## Evidence and Limits
+
+The progression is visible in commit `8f10fb7` (direct recording), deployment
+corrections including `6e626bc`, and commit `5ed90b5` (reliable upload-only
+flow), merged through PR
+[#23](https://github.com/usekina/kina/pull/23).
+
+The record shows a reasoned product correction. It does not yet contain a
+published device matrix, failure-rate dataset, or controlled usability study.
+Future reintroduction of direct recording should require those acceptance
+criteria.
+
+## Discussion Questions
+
+1. When should a team remove a convenient but unreliable feature?
+2. Which device and browser conditions belong in an acceptance matrix?
+3. How should negative results be documented without exposing user data?

--- a/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-08-02-feedback-to-data-product.md
+++ b/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-08-02-feedback-to-data-product.md
@@ -1,8 +1,14 @@
-# Teaching Case: From User Feedback to a Mobile Data Product
+# Practical Learning Case: From User Feedback to a Data Product
 
-This case is designed for a university data science or startup milestone
-lecture. It uses an anonymized KinaBot product iteration to show how qualitative
-feedback becomes a testable data-product decision.
+**Date:** 2026-08-02
+
+**Status:** Feedback translated into an implemented and documented change
+
+**Source:** Anonymized external product feedback and PR #27
+
+This case uses an anonymized KinaBot product iteration to show how qualitative
+feedback becomes a testable data-product decision. It is written as reusable
+practical knowledge for learners, researchers, engineers, and product teams.
 
 ## Learning Objectives
 
@@ -38,6 +44,21 @@ destination, a one-feature-at-a-time trend chart, recent/all history controls,
 and a versioned scoring explanation. Research administration remains
 permission-gated and outside the participant's primary flow.
 
+## Maintainer Reflection
+
+> I learned not to treat feedback as a list of requested features. The deeper
+> task was to find the unmet need: a mobile user wanted to understand the
+> current result, return to it, and see change over time without being buried in
+> technical detail. One comment affected navigation, visualization, scoring
+> explanation, privacy separation, and future validation questions.
+
+## Reusable Knowledge
+
+- Preserve the original observation separately from the proposed solution.
+- Translate qualitative feedback into testable product and data requirements.
+- Make methodology reachable without forcing it into the primary user path.
+- Link feedback, decision, implementation, test, and remaining measurement gap.
+
 ## Discussion Questions
 
 - Does a 0–100 scale create unintended health-score expectations?
@@ -55,4 +76,18 @@ reasoning. It does not by itself establish adoption, educational impact,
 clinical validity, or extraordinary professional impact. Course delivery,
 independent feedback, usage results, permissions, and external recognition
 should be retained separately as verifiable evidence.
+
+Public evidence includes the anonymized
+[feedback record](../../feedback/2026-08-mobile-results-navigation.md), the
+[mobile architecture note](../../ux/MOBILE-FIRST-RESULTS.md), and PR
+[#27](https://github.com/usekina/kina/pull/27).
+
+## Follow-On Session
+
+The dated learning case
+[From Online Product to Offline University Research](2026-08-05-offline-university-research.md)
+extends this teaching material from mobile product feedback to contextual data
+engineering. It asks students to redesign identity, model distribution, network
+boundaries, pseudonymisation, validation, and institutional responsibility when
+the same application enters a privacy-sensitive university research setting.
 

--- a/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-08-05-dignity-first-validation.md
+++ b/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-08-05-dignity-first-validation.md
@@ -1,0 +1,67 @@
+# Dignity First: Changing Product Success and Evidence Standards
+
+**Date:** 2026-08-05
+
+**Status:** Product, governance, and documentation framework established
+
+**Source:** Dignity-first redesign and validation-governance work
+
+## Background
+
+A healthy-aging product can unintentionally turn reflection into surveillance,
+competition, or fear. Streaks can punish missed days. Scores can feel like
+grades. Caregiver features can weaken the older adult's agency. Warm language
+can still conceal unsupported health implications.
+
+The project needed a definition of success that included how a person is
+treated, not only whether the software produced an output.
+
+## Decision
+
+KinaBot adopted a dignity-first product identity centered on longitudinal speech
+reflection, healthy aging, and family-centered care. The experience recommends
+one short daily reflection, makes additional check-ins optional, avoids streak
+penalties, explains features without diagnosis, and separates participant and
+research-administration flows.
+
+The same release established validation gates, an AI risk register, and
+evidence-defined impact metrics. This connected product values to release and
+claim discipline.
+
+## Maintainer Reflection
+
+> I learned that dignity must be visible in small technical choices: whether a
+> missed day is punished, whether a caregiver sees more than the participant
+> expects, whether a score looks like a diagnosis, and whether uncertainty is
+> stated before promotion. Human-centered technology is a continuing governance
+> practice, not a friendly visual style.
+
+## Reusable Knowledge
+
+- Translate values into interface behavior, permissions, metrics, and release
+  gates.
+- Measure burden, comprehension, accessibility, and user agency—not engagement
+  alone.
+- Keep engineering verification, usability evidence, and clinical validation
+  as distinct layers.
+- Record risks before external attention makes them inconvenient to disclose.
+
+## Evidence and Limits
+
+The work is recorded in PR
+[#28](https://github.com/usekina/kina/pull/28),
+[`RESPONSIBLE-WELLNESS-DESIGN.md`](../../RESPONSIBLE-WELLNESS-DESIGN.md),
+[`AI-RISK-REGISTER.md`](../../AI-RISK-REGISTER.md),
+[`VALIDATION-PLAN.md`](../../VALIDATION-PLAN.md), and
+[`IMPACT-METRICS.md`](../../IMPACT-METRICS.md).
+
+This framework demonstrates responsible preparation. It is not proof that users
+experience dignity, that families benefit, or that the product improves health.
+Those claims require consented studies and independent evidence.
+
+## Discussion Questions
+
+1. Which product metrics can conflict with dignity?
+2. How should participant agency shape family-centered features?
+3. What evidence separates an appealing responsible-AI framework from an
+   effective one?

--- a/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-08-05-offline-university-research.md
+++ b/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-08-05-offline-university-research.md
@@ -1,0 +1,230 @@
+# From Online Product to Offline University Research
+
+Date initiated: 2026-08-05
+
+Status: Engineering implementation merged; institutional review and complete
+OS-specific delivery bundle remain pending
+
+Source: Paraphrased request from a prospective UK university researcher
+
+Context: The researcher had previously asked whether KinaBot could be used
+offline. The current Aoi-maintained application had become locally scored and
+privacy-aware, but its identity, dependency installation, and model-loading
+assumptions still reflected an online product environment.
+
+Public-record basis: GitHub PR #29, merge commit `754a58d`, automated tests,
+design records, and the documents linked below
+
+## Background
+
+KinaBot began as an online speech-reflection product. A returning user entered
+an email, received a verification code, and built a personal history. The core
+feature engine and transcription were local to the KinaBot environment, while
+email delivery and an optional, limited OpenAI insight layer could use external
+services.
+
+That architecture can be reasonable for an online pilot. It does not
+automatically fit a university study conducted on an offline or air-gapped
+computer. A different social and institutional environment changed the meaning
+of otherwise ordinary design choices.
+
+## Trigger
+
+The prospective researcher wanted to use KinaBot offline. This created a more
+specific engineering question:
+
+> Can a university team install, identify participants, transcribe speech,
+> calculate longitudinal features, export research data, and verify the system
+> without relying on email, cloud AI, or an undisclosed network download?
+
+The correct response required more than adding an `offline=true` label.
+
+## Competing Requirements
+
+| Requirement | Tension created |
+|---|---|
+| Longitudinal identity | Recognize repeat sessions without collecting email |
+| Research confidentiality | School IDs may be short and easy to guess |
+| No external transfer | SMTP, OpenAI, telemetry, and model downloads must not occur |
+| Reproducibility | Fix and record model, dependency, code, and scoring versions |
+| Ease of use | Avoid requiring researchers to reconstruct Python manually |
+| Institutional control | University controls device, linkage key, retention, and approvals |
+| Honest claims | Offline engineering is not automatic GDPR compliance or ethics approval |
+
+## Alternatives Considered
+
+### Continue using email with a locally displayed code
+
+This works without SMTP but collects an identifier the study may not need. It
+was rejected for the formal offline mode.
+
+### Store the school participant ID directly
+
+This is simple but makes the database immediately identifiable to anyone with
+the participant list. It was rejected.
+
+### Store `SHA256("001")`
+
+This hides the visible value but is weak because an attacker can calculate the
+small range of possible hashes. It was replaced with a study-secret HMAC.
+
+### Keep external AI available when an API key exists
+
+This would make offline behavior depend on configuration discipline. It was
+rejected in favor of a code-level boundary that always selects the local action
+library.
+
+### Let `faster-whisper` load a model by name
+
+This can trigger a first-run download. Offline mode instead requires an existing
+local directory and stops with a clear error if the model is absent.
+
+## Decision
+
+KinaBot Offline Research Mode now:
+
+- accepts a school-assigned ID such as `001`;
+- stores a keyed, study-specific HMAC pseudonym rather than the raw ID;
+- collects no participant email and bypasses SMTP;
+- disables OpenAI even if an API key is present;
+- requires a preinstalled local Whisper model path;
+- binds its standard launcher to `127.0.0.1`;
+- retains local SQLite history and de-identified research export; and
+- records the delivery bundle's Git commit and SHA-256 manifest.
+
+The university retains responsibility for the separate participant linkage
+file, lawful basis, special-category-data analysis, ethics review, DPIA decision,
+device security, retention, deletion, and incident response.
+
+## Implementation
+
+```text
+School-assigned ID
+  -> local validation
+  -> HMAC(study secret, normalized ID)
+  -> SQLite participant key
+
+Approved audio file
+  -> temporary local file
+  -> preinstalled faster-whisper model
+  -> versioned Python/NLP features
+  -> local longitudinal record
+  -> temporary audio and full transcript deleted
+
+Offline trend
+  -> local curated action library
+  -> no SMTP or OpenAI path
+```
+
+Delivery materials include an offline requirements file, installer, launcher,
+bundle builder, checksum manifest, verifier, quick start, research guide, and
+UK/EU data-protection readiness checklist.
+
+## What Failed or Changed
+
+### Ordinary hashing was not sufficient
+
+The first implementation used a domain-separated SHA-256 hash. Review identified
+that IDs such as `001` have too little entropy. The design was corrected before
+release to use a study-secret HMAC. This also created a new responsibility: the
+secret must be backed up securely because losing it breaks longitudinal linkage.
+
+### The official model download was blocked
+
+An attempt to download the Whisper model from its official source was blocked by
+TLS certificate verification on a controlled enterprise network. SSL
+verification was not disabled. The lesson is that an offline application needs
+an institution-approved model and dependency acquisition process, not an
+insecure workaround.
+
+### A health endpoint was not a full user test
+
+The Streamlit health endpoint returned `200 ok`, but it did not create a user
+session. A second test used Streamlit AppTest to open the app, enter `001`, and
+continue. It confirmed that SQLite stored neither an email nor the raw ID.
+
+## Verification
+
+- Python compilation passed.
+- 24 automated tests passed.
+- Offline ID `001` AppTest login passed.
+- SQLite contained no email or raw `001` value.
+- Different study secrets produced different pseudonyms for the same ID.
+- OpenAI remained disabled with a test API key present.
+- Missing model configuration failed before reading audio.
+- Four PowerShell delivery scripts parsed successfully.
+- GitHub Actions passed.
+- PR #29 was merged to `main` on 2026-08-06 UTC.
+
+The complete disconnected transcription bundle remains unverified until an
+approved OS-specific wheelhouse and model are tested in the target university
+environment.
+
+## Remaining Risks and Evidence Gaps
+
+- Target OS, Python version, CPU, and air-gap policy are unknown.
+- University ethics, DPO, information-governance, and security review are pending.
+- Pseudonymised data may remain personal data; HMAC is not anonymisation.
+- Model and dependency licenses require institutional review.
+- Secret backup and recovery need an acceptance exercise.
+- Independent installation and usability are not yet demonstrated.
+- No institutional adoption, endorsement, or research outcome is claimed.
+
+## Social and Human-Centered Meaning
+
+Software requirements are not determined by code alone. Email may support
+continuity in a consumer service while creating unnecessary collection in a
+study. Cloud APIs may improve convenience while conflicting with an air-gap
+protocol. A hashed identifier may appear private while remaining guessable.
+
+Responsible data science requires contextual engineering: understand who
+controls the system, who bears risk, what institution governs it, what data is
+necessary, and how one technical control can create a new human or operational
+responsibility.
+
+## Student Exercise
+
+Assume a university wants a 12-week study with 60 participants. Produce:
+
+1. a data-flow diagram and inventory;
+2. a threat model for IDs, audio, models, exports, and the study secret;
+3. an Article 6/Article 9 question list for the university DPO without making a
+   legal conclusion;
+4. a retention and deletion schedule;
+5. an offline acceptance plan;
+6. a response to loss of the participant-key secret;
+7. three accessibility risks; and
+8. an approve, restrict, delay, or reject recommendation.
+
+Distinguish implemented evidence, assumptions, and evidence still needed.
+
+## Discussion Questions
+
+- Is an offline system always more private than a managed cloud system?
+- Who should hold the participant linkage file and HMAC secret?
+- What happens when a participant requests deletion using only the school ID?
+- When does speech data become health or biometric data?
+- Can the records be reused for a second study?
+- What evidence is needed before discussing health-related meaning?
+- Is a failed secure download an obstacle or a safety signal?
+- How does the design change for macOS, Linux, shared devices, or multi-site use?
+
+## Evidence Links
+
+- Pull request: https://github.com/usekina/kina/pull/29
+- Merge commit: https://github.com/usekina/kina/commit/754a58deda8b4fc3866ef9bf186884d93271b22b
+- [Offline Quick Start](../../../OFFLINE-QUICKSTART.md)
+- [Offline Research Guide](../../OFFLINE-RESEARCH-GUIDE.md)
+- [UK/EU Data-Protection Readiness](../../UK-EU-DATA-PROTECTION-READINESS.md)
+- [Offline Bundle Manifest](../../OFFLINE-BUNDLE-MANIFEST.md)
+- [University Offline Research Milestone](../../education/UNIVERSITY-OFFLINE-RESEARCH-MILESTONE.md)
+- [AI Risk Register](../../AI-RISK-REGISTER.md)
+- [Validation Plan](../../VALIDATION-PLAN.md)
+
+## Reuse and Claims Boundary
+
+This case documents one project's reasoning and implementation. It is not legal,
+medical, cybersecurity, or research-ethics advice. It does not establish GDPR
+compliance, clinical validity, university approval, adoption, educational impact,
+or field-wide significance. Those conclusions require separate institutional
+and independent evidence.

--- a/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/README.md
+++ b/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/README.md
@@ -1,0 +1,24 @@
+# Aoi-Maintained Product: Independent Development Lessons
+
+This collection covers the new application direction under
+`aoi_kinabot_app/`. The preserved path-specific Git history attributes its
+commits to Aoi Minamoto. It records how Aoi developed and maintained the product
+boundary, deterministic scoring, multilingual system, longitudinal experience,
+privacy architecture, reliability decisions, dignity-first design, validation
+governance, and offline research mode.
+
+## Cases
+
+- [Observable Features, Not Diagnosis](2026-06-11-observable-features-not-diagnosis.md)
+- [Multilingual Design Is More Than Translation](2026-07-28-multilingual-longitudinal-design.md)
+- [Removing a Feature When Reliability Was Not Good Enough](2026-07-29-to-31-recording-reliability.md)
+- [From User Feedback to a Data Product](2026-08-02-feedback-to-data-product.md)
+- [Dignity First](2026-08-05-dignity-first-validation.md)
+- [From Online Product to Offline University Research](2026-08-05-offline-university-research.md)
+
+## Reading Boundary
+
+This collection supports transparent claims about recorded development,
+maintainership, reasoning, and continuous contribution. It does not by itself
+prove exclusive legal inventorship, scientific validity, adoption, or major
+field-wide significance. Those questions require their own evidence.

--- a/aoi_kinabot_app/docs/learning-cases/collaborative-exploration/2025-05-to-2026-06-origin-collaboration-boundary.md
+++ b/aoi_kinabot_app/docs/learning-cases/collaborative-exploration/2025-05-to-2026-06-origin-collaboration-boundary.md
@@ -1,0 +1,83 @@
+# Origin, Collaboration, and an Independent Product Boundary
+
+**Period:** May 2025 to June 2026
+
+**Status:** Retrospective case based on preserved repository history
+
+**Source:** Founder record, Git history, and maintained-project documentation
+
+## Background
+
+KinaBot's maintained founder record traces its product origin and MVP launch to
+an early concept called Kizuna in May 2025. This is provenance supplied by the
+founder, not a Git timestamp. The repository's preserved history across all
+refs begins on 2025-11-28; the current maintained branch contains a later
+reconstructed history beginning on 2026-06-11. The early work explored
+speech-derived cognitive insights, Streamlit delivery, privacy
+notices, testing, reports, and frontend/backend separation. It includes
+identifiable contributions from Irene Li and Yuan Chen as well as Aoi Minamoto's
+founding, integration, maintenance, and product direction.
+
+The early materials are preserved because provenance matters. They also contain
+concepts such as cognitive age, overall scores, and risk-style presentation that
+do not define the maintained product today.
+
+## Trigger
+
+As the work moved from exploration toward a product that people might use for
+healthy-aging reflection, historical experiments and current behavior could no
+longer share an ambiguous boundary. Readers needed to know who contributed,
+what Aoi currently maintained, and which older claims were no longer accepted.
+
+## Decision
+
+On 2026-06-11, Aoi created `aoi_kinabot_app/` as a separately documented new
+version and independent technical direction. Historical collaborative work and
+all identifiable contributors remained visible outside that directory. The Git
+record for `aoi_kinabot_app/` attributes its development and maintenance to Aoi
+Minamoto; the new directory established its own plans, privacy model, scoring
+design, tests, database helpers, interface, and contribution rules.
+
+This does not convert historical collaborative work into Aoi's sole work. It
+creates an auditable boundary around the new application that Aoi independently
+developed, directed, and continues to maintain.
+
+## Maintainer Reflection
+
+> I learned that leadership is not demonstrated by removing other people's
+> history. It is demonstrated by preserving provenance, defining the new
+> responsibility clearly, and continuing to make verifiable decisions over
+> time. A clean boundary made both collaboration and independent contribution
+> easier to understand.
+
+## Reusable Knowledge
+
+- Preserve early work even when the product direction changes.
+- Separate founder, maintainer, author, owner, and inventor; they are not the
+  same legal or technical role.
+- Establish a maintained boundary with code, documentation, tests, and decision
+  authority—not merely a new product name.
+- Attribute collaborators precisely and never use later leadership to erase
+  earlier contributions.
+
+## Evidence and Limits
+
+Evidence includes the current repository history, the 2026-06-11 commit
+[`8a92fd8`](https://github.com/usekina/kina/commit/8a92fd8), and
+[`OWNERSHIP-AND-MAINTAINERSHIP.md`](../../../OWNERSHIP-AND-MAINTAINERSHIP.md).
+The broader chronology is documented in
+[`PROJECT-EVOLUTION.md`](../../PROJECT-EVOLUTION.md).
+
+The May 2025 MVP launch should be supported separately by contemporaneous records
+if it is used in a formal proceeding. The repository supports a record of
+contribution and continuity from its preserved commit history. It does not,
+by itself, determine patent inventorship, prove exclusive authorship of all
+historical work, or establish field-wide impact.
+
+## Discussion Questions
+
+1. How can a founder preserve collaboration while establishing a new product
+   boundary?
+2. Which artifacts show ongoing technical leadership better than commit count?
+3. When does a redesign become a distinct maintained system rather than a
+   continuation of an experiment?

--- a/aoi_kinabot_app/docs/learning-cases/collaborative-exploration/README.md
+++ b/aoi_kinabot_app/docs/learning-cases/collaborative-exploration/README.md
@@ -1,0 +1,32 @@
+# Collaborative Exploration: Lessons and Provenance
+
+This collection covers the original Kina/KinaBot exploration before the new
+`aoi_kinabot_app/` boundary. It preserves every identifiable contributor rather
+than retrospectively assigning the whole phase to one person.
+
+## Recorded Contributors
+
+- **Aoi Minamoto:** product origin and direction, initial open-source work,
+  integration, repository maintenance, privacy, security, documentation, and
+  continuing decisions.
+- **Irene Li:** code upload and run documentation recorded in December 2025.
+- **Yuan Chen:** testing, CI, PDF and scoring experiments, dependency and code
+  quality work, signal documentation, and frontend/backend structure recorded
+  from December 2025 to January 2026.
+
+Names and summaries reflect the preserved Git history. They do not decide legal
+inventorship or ownership.
+
+## Core Learning
+
+Exploration can be valuable even when its claims, architecture, and product
+direction later change. The responsible response is to retain provenance,
+credit the work precisely, identify what is no longer current, and make the
+transition to a new maintained system explicit.
+
+## Case
+
+- [Origin, Collaboration, and an Independent Product Boundary](2025-05-to-2026-06-origin-collaboration-boundary.md)
+
+For exact commits and the path-specific authorship boundary, see the
+[Evidence Map](../EVIDENCE-MAP.md).


### PR DESCRIPTION
## What changed

- establishes a dated KinaBot Product Learning Archive
- separates collaborative exploration from the Aoi-maintained application
- preserves contributor attribution and path-specific authorship boundaries
- adds a Journey Timeline and commit/PR Evidence Map
- publishes seven evidence-linked learning cases with maintainer reflections
- adds a globally reusable Open Curriculum
- adds a September 2026 white paper preparation roadmap
- removes institution-specific teaching references from the public materials

## Why

The archive turns first-hand product development into inspectable, reusable education for students, researchers, engineers, designers, and product teams. It records decisions, failures, corrections, verification, and evidence gaps instead of presenting development history as promotion.

## Claims boundary

This PR does not claim institutional endorsement or adoption, clinical validity, legal compliance, educational impact, or field-wide significance. The May 2025 MVP launch is identified as founder-reported provenance pending a contemporaneous supporting artifact. Git chronology and contributor claims are linked to preserved repository history.

## Validation

- `git diff --check`
- internal Markdown link validation: 0 missing links
- repository-wide check confirms no institution-specific teaching name remains in `aoi_kinabot_app`
- documentation-only change; no application runtime behavior changed