### PR TITLE
Add dignity-centered AImoji product principles

### DIFF
--- a/aoi_kinabot_app/docs/learning-cases/EVIDENCE-MAP.md
+++ b/aoi_kinabot_app/docs/learning-cases/EVIDENCE-MAP.md
@@ -23,6 +23,7 @@ field-wide significance.
 | Dignity-first design and validation governance | [`f6f3134`](https://github.com/usekina/kina/commit/f6f3134), [`c99dcd1`](https://github.com/usekina/kina/commit/c99dcd1) | [PR #28](https://github.com/usekina/kina/pull/28), [Risk Register](../AI-RISK-REGISTER.md), and [Validation Plan](../VALIDATION-PLAN.md) |
 | Offline research mode | [`5a23963`](https://github.com/usekina/kina/commit/5a23963) | [PR #29](https://github.com/usekina/kina/pull/29) and [Offline Research Guide](../OFFLINE-RESEARCH-GUIDE.md) |
 | Explicit controls for data-loss actions | [`386bf0f`](https://github.com/usekina/kina/commit/386bf0f) | [AImoji Maintainer Principles](../../../docs/maintainer-principles.md) |
+| Dignity through equitable access and longitudinal awareness | [`2075664`](https://github.com/usekina/kina/commit/2075664) | [AImoji Maintainer Principles](../../../docs/maintainer-principles.md) |
 
 ## Authorship Boundary
 

--- a/aoi_kinabot_app/docs/learning-cases/EVIDENCE-MAP.md
+++ b/aoi_kinabot_app/docs/learning-cases/EVIDENCE-MAP.md
@@ -22,6 +22,7 @@ field-wide significance.
 | Mobile trends from feedback | [`484fd80`](https://github.com/usekina/kina/commit/484fd80), [`56cf22d`](https://github.com/usekina/kina/commit/56cf22d) | [PR #27](https://github.com/usekina/kina/pull/27) and [feedback record](../feedback/2026-08-mobile-results-navigation.md) |
 | Dignity-first design and validation governance | [`f6f3134`](https://github.com/usekina/kina/commit/f6f3134), [`c99dcd1`](https://github.com/usekina/kina/commit/c99dcd1) | [PR #28](https://github.com/usekina/kina/pull/28), [Risk Register](../AI-RISK-REGISTER.md), and [Validation Plan](../VALIDATION-PLAN.md) |
 | Offline research mode | [`5a23963`](https://github.com/usekina/kina/commit/5a23963) | [PR #29](https://github.com/usekina/kina/pull/29) and [Offline Research Guide](../OFFLINE-RESEARCH-GUIDE.md) |
+| Explicit controls for data-loss actions | [`386bf0f`](https://github.com/usekina/kina/commit/386bf0f) | [AImoji Maintainer Principles](../../../docs/maintainer-principles.md) |
 
 ## Authorship Boundary
 

--- a/aoi_kinabot_app/docs/learning-cases/JOURNEY-TIMELINE.md
+++ b/aoi_kinabot_app/docs/learning-cases/JOURNEY-TIMELINE.md
@@ -88,6 +88,9 @@ implemented behavior, and future goals.
 - The 30-day experience emphasized one recommended reflection, optional extra
   check-ins, and no streak penalty.
 - Dignity-first language and family-centered boundaries were consolidated.
+- Equitable access to longitudinal awareness was documented as a product
+  purpose, using feature direction, magnitude, and variability as a mirror
+  without claiming direct measurement of cognitive, brain, or neural change.
 - Validation gates, an AI risk register, impact metrics, and a project-evolution
   record were established.
 - **Takeaway:** human-centered values need release gates and evidence rules.

--- a/aoi_kinabot_app/docs/learning-cases/OPEN-CURRICULUM.md
+++ b/aoi_kinabot_app/docs/learning-cases/OPEN-CURRICULUM.md
@@ -75,6 +75,11 @@ power, accessibility, and unmeasured harm.
 turns dignity into concrete destructive-action, warning, recovery, and
 privacy-retention requirements.
 
+**Companion case:** [Dignity Through Access and Awareness](aoi-maintained-product/2026-08-05-dignity-through-access-awareness.md)
+examines inequitable access and the use of longitudinal feature direction,
+magnitude, and variability as a mirror without converting observations into
+clinical or neurological claims.
+
 ## Module 7 · Context Changes the System
 
 **Case:** [From Online Product to Offline University Research](aoi-maintained-product/2026-08-05-offline-university-research.md)

--- a/aoi_kinabot_app/docs/learning-cases/OPEN-CURRICULUM.md
+++ b/aoi_kinabot_app/docs/learning-cases/OPEN-CURRICULUM.md
@@ -71,6 +71,10 @@ impact metrics, validation gates, and claims discipline.
 **Practice:** audit a wellness feature for coercion, overclaiming, caregiver
 power, accessibility, and unmeasured harm.
 
+**Companion case:** [Users Must Never Have to Guess About Data Loss](aoi-maintained-product/2026-08-05-explicit-data-loss-controls.md)
+turns dignity into concrete destructive-action, warning, recovery, and
+privacy-retention requirements.
+
 ## Module 7 · Context Changes the System
 
 **Case:** [From Online Product to Offline University Research](aoi-maintained-product/2026-08-05-offline-university-research.md)

--- a/aoi_kinabot_app/docs/learning-cases/README.md
+++ b/aoi_kinabot_app/docs/learning-cases/README.md
@@ -128,6 +128,7 @@ all meaningful milestones. The cases below examine the largest learning turns.
 - [2026-08-05 · Dignity First: Changing Product Success and Evidence Standards](aoi-maintained-product/2026-08-05-dignity-first-validation.md)
 - [2026-08-05 · From Online Product to Offline University Research](aoi-maintained-product/2026-08-05-offline-university-research.md)
 - [2026-08-05 · Users Must Never Have to Guess About Data Loss](aoi-maintained-product/2026-08-05-explicit-data-loss-controls.md)
+- [2026-08-05 · Dignity Through Access and Awareness](aoi-maintained-product/2026-08-05-dignity-through-access-awareness.md)
 
 ## The Next Cases Must Be Earned
 

--- a/aoi_kinabot_app/docs/learning-cases/README.md
+++ b/aoi_kinabot_app/docs/learning-cases/README.md
@@ -127,6 +127,7 @@ all meaningful milestones. The cases below examine the largest learning turns.
 - [2026-08-02 · From User Feedback to a Data Product](aoi-maintained-product/2026-08-02-feedback-to-data-product.md)
 - [2026-08-05 · Dignity First: Changing Product Success and Evidence Standards](aoi-maintained-product/2026-08-05-dignity-first-validation.md)
 - [2026-08-05 · From Online Product to Offline University Research](aoi-maintained-product/2026-08-05-offline-university-research.md)
+- [2026-08-05 · Users Must Never Have to Guess About Data Loss](aoi-maintained-product/2026-08-05-explicit-data-loss-controls.md)
 
 ## The Next Cases Must Be Earned
 

--- a/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-08-05-dignity-through-access-awareness.md
+++ b/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-08-05-dignity-through-access-awareness.md
@@ -1,0 +1,128 @@
+# Dignity Through Access and Awareness
+
+**Date:** 2026-08-05
+
+**Status:** AImoji product-purpose principle documented
+
+**Source:** Aoi Minamoto's first-hand professional observation and reflection
+
+## Observation
+
+Aoi observed that some people lack health insurance or cannot readily access
+cognitive-health evaluation. Financial constraints, race-related inequities,
+geography, language, and uneven service availability can affect whether a
+person receives understandable information or timely professional support.
+Changes may remain unnoticed, and families may not know when a pattern began or
+when a conversation about evaluation could be useful.
+
+This is a personal professional observation and design motivation. It is not
+presented here as a prevalence study or a measured causal finding.
+
+## Human-Centered Question
+
+Should every person have a fair opportunity to understand whether meaningful
+patterns may be changing in their health, cognition, or everyday functioning,
+and to decide what to do next?
+
+AImoji's answer is that access to understandable information and appropriate
+evaluation should not depend on income, insurance status, race, language, or
+geography. Awareness supports dignity only when it also preserves agency,
+privacy, cultural context, and freedom from unsupported judgment.
+
+## Product Principle
+
+> Human-centered technology should reduce barriers to longitudinal awareness
+> and informed action without replacing diagnosis or claiming to measure what
+> its evidence cannot establish.
+
+For KinaBot, this means helping a person observe patterns in their own speech
+and language expression over time. It does not mean claiming that a voice sample
+directly reveals a change in the brain or nervous system.
+
+## KinaBot as a Longitudinal Mirror
+
+“以此为镜”—use it as a mirror—is the intended metaphor. Under a stable,
+versioned method, KinaBot can quantify the direction, magnitude, and variability
+of defined speech and language features across a period of time. It can help a
+person see that a feature has moved lower, higher, or become more variable than
+their own earlier pattern.
+
+The mirror does not explain the cause. A lower feature value is not equivalent
+to cognitive decline, and greater variability is not evidence of a brain or
+neurological disorder. Recording conditions, language, illness, fatigue,
+medication, stress, device differences, and scoring-version changes may all
+affect the observed pattern.
+
+## Product Requirements
+
+- Make the primary experience understandable without specialist vocabulary.
+- Support linguistic and cultural accessibility rather than word-for-word
+  translation alone.
+- Design for low-cost and geographically distributed access where feasible.
+- Explain what each observation can and cannot mean.
+- Show feature direction, magnitude, and variability over time without
+  relabeling feature change as medical decline.
+- Preserve the individual's control over family sharing and follow-up.
+- Avoid diagnosis, cognitive-age, disease-risk, or neurological-change claims
+  without appropriate independent evidence and review.
+- Provide a clear path from awareness to qualified professional evaluation when
+  concern exists.
+- Measure whether access, comprehension, and follow-up are equitable across
+  relevant groups instead of assuming that availability creates fairness.
+
+## Maintainer Reflection
+
+> I have seen people remain unaware of possible cognitive change because
+> evaluation and understandable information were not equally accessible. I
+> believe people have a right to live with dignity and to have a fair opportunity
+> to understand meaningful changes in their own lives. Technology should help
+> lower that barrier, but it must not replace one injustice with another by
+> offering unsupported conclusions or taking away a person's agency.
+
+## Tension to Preserve
+
+Two harms must be addressed together:
+
+1. **Under-access:** people may lack affordable, local, or language-accessible
+   ways to notice patterns and seek help.
+2. **Over-interpretation:** an accessible AI tool may falsely imply diagnosis or
+   direct knowledge of brain and neurological change.
+
+A dignity-centered product must resist both. Wider access is not responsible if
+the information is misleading; scientific caution is not equitable if it is
+used as a reason to ignore access barriers.
+
+## Student Exercise
+
+Design an awareness tool for a population facing financial, geographic, or
+language barriers. Specify:
+
+1. what the tool observes;
+2. what it explicitly does not infer;
+3. how users understand uncertainty;
+4. how privacy and individual agency are preserved;
+5. how a user can seek qualified follow-up; and
+6. what disaggregated evidence would be needed to evaluate equitable access and
+   benefit.
+
+## Discussion Questions
+
+1. Is access to a tool meaningful if professional follow-up remains
+   inaccessible?
+2. How can a product support family communication without weakening the
+   individual's control?
+3. Which metrics could reveal that a multilingual product remains inequitable?
+4. How should a team discuss early awareness without creating fear or implying
+   diagnosis?
+
+## Evidence and Claims Boundary
+
+The formal principle is recorded in
+[`docs/maintainer-principles.md`](../../../../docs/maintainer-principles.md) and
+the initial documented principle is commit
+[`2075664`](https://github.com/usekina/kina/commit/2075664).
+
+This case documents Aoi's motivation and the product requirements derived from
+it. It does not establish population prevalence, clinical effectiveness,
+equitable outcomes, or a human-rights determination in law. Those claims require
+appropriate research, legal analysis, and independent evidence.

--- a/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-08-05-explicit-data-loss-controls.md
+++ b/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-08-05-explicit-data-loss-controls.md
@@ -1,0 +1,102 @@
+# Users Must Never Have to Guess About Data Loss
+
+**Date:** 2026-08-05
+
+**Status:** AImoji product principle documented
+
+**Source:** First-hand product reflection by Aoi Minamoto
+
+## Trigger
+
+An interface can cause real harm even when its underlying data operation is
+technically correct. If a button, icon, toggle, navigation step, replacement
+flow, or timeout can remove user data, the user may discover the consequence
+only after recovery is impossible.
+
+This is especially important in human-centered and health-adjacent products,
+where a record may contain personal effort, reflection, family context, or
+sensitive information that cannot simply be recreated.
+
+## Founder Principle
+
+> 任何会导致用户数据丢失的操作，都必须有明确的按钮、明确的提示，并且不能依赖用户猜测。
+
+> Any operation that can cause the loss of user data must have an explicit
+> control and an explicit warning. It must never depend on the user guessing
+> the consequence.
+
+## Product Requirements
+
+A user-facing destructive action must provide:
+
+- a distinct, intentionally labeled control;
+- a plain-language explanation of exactly what will be lost;
+- a statement about whether recovery is possible;
+- confirmation proportionate to the severity of the loss; and
+- a safe default that preserves data.
+
+Destructive behavior must not be concealed behind an ambiguous icon,
+navigation, toggle, timeout, or unrelated primary action.
+
+## Important Boundary: Privacy Deletion
+
+Not every deletion should require a user to press a delete button. KinaBot, for
+example, removes temporary audio after processing to minimize sensitive-data
+retention. Such automatic lifecycle deletion is appropriate when it is:
+
+- disclosed before data collection;
+- necessary for a stated privacy or retention purpose;
+- applied consistently on success and failure paths; and
+- verified by tests and operational records.
+
+This distinction prevents a transparency principle from accidentally weakening
+privacy-by-design behavior.
+
+## Maintainer Reflection
+
+> I learned that a technically available function is not an understandable
+> choice. If people must guess whether an action will erase their work, the
+> interface has transferred product responsibility to the user. Dignity means
+> making the consequence visible before the loss occurs.
+
+## Reusable Knowledge
+
+- Treat destructive actions as a separate interaction class.
+- Name the affected data, not merely the operation.
+- Match confirmation friction to severity and reversibility.
+- Test comprehension and recovery, not only whether deletion executes.
+- Distinguish user-initiated destruction from disclosed retention automation.
+- Record deletion events without logging the sensitive content being deleted.
+
+## Student Exercise
+
+Choose a product flow involving delete, reset, overwrite, replacement, account
+closure, retention expiry, or import. Produce:
+
+1. a data-loss inventory;
+2. button and warning copy;
+3. confirmation and recovery behavior;
+4. accessibility and localization requirements;
+5. tests for accidental activation and failure recovery; and
+6. a separate analysis of any privacy-required automatic deletion.
+
+## Discussion Questions
+
+1. When does confirmation protect a user, and when does it become habituating
+   friction?
+2. Which losses require undo, a recovery window, or administrator support?
+3. How should destructive-action warnings work for older adults, screen-reader
+   users, and multilingual audiences?
+4. When can privacy-preserving automatic deletion occur without an immediate
+   button press?
+
+## Evidence and Claims Boundary
+
+The formal rule is recorded in
+[`docs/maintainer-principles.md`](../../../../docs/maintainer-principles.md) and its
+initial implementation record is commit
+[`386bf0f`](https://github.com/usekina/kina/commit/386bf0f).
+
+This case documents a product-governance principle. It does not establish that
+every current interface already satisfies the rule. Product-specific audits and
+tests are required before making that claim.

--- a/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/README.md
+++ b/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/README.md
@@ -15,6 +15,7 @@ governance, and offline research mode.
 - [From User Feedback to a Data Product](2026-08-02-feedback-to-data-product.md)
 - [Dignity First](2026-08-05-dignity-first-validation.md)
 - [From Online Product to Offline University Research](2026-08-05-offline-university-research.md)
+- [Users Must Never Have to Guess About Data Loss](2026-08-05-explicit-data-loss-controls.md)
 
 ## Reading Boundary
 

--- a/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/README.md
+++ b/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/README.md
@@ -16,6 +16,7 @@ governance, and offline research mode.
 - [Dignity First](2026-08-05-dignity-first-validation.md)
 - [From Online Product to Offline University Research](2026-08-05-offline-university-research.md)
 - [Users Must Never Have to Guess About Data Loss](2026-08-05-explicit-data-loss-controls.md)
+- [Dignity Through Access and Awareness](2026-08-05-dignity-through-access-awareness.md)
 
 ## Reading Boundary
 

--- a/docs/maintainer-principles.md
+++ b/docs/maintainer-principles.md
@@ -37,3 +37,29 @@ The project should not encourage automated care decisions without qualified huma
 New features should align with KinaBot's safety, privacy, and dignity boundaries.
 
 If a feature increases risk for users, families, or older adults, it should be delayed, redesigned, or rejected.
+
+## 7. Data-Loss Actions Must Be Explicit
+
+**Documented:** 2026-08-05
+
+**Scope:** AImoji product design and implementation
+
+> **AImoji founder principle:** 任何会导致用户数据丢失的操作，都必须有明确的按钮、明确的提示，并且不能依赖用户猜测。
+
+Any user-facing action that can delete, replace, reset, or otherwise cause the
+loss of user data must provide:
+
+- a distinct and intentionally labeled control;
+- a plain-language warning that identifies what data will be lost;
+- a clear statement about whether recovery is possible; and
+- confirmation proportionate to the severity and reversibility of the loss.
+
+Destructive behavior must not be hidden behind navigation, an ambiguous icon, a
+toggle, a timeout, or an action whose data-loss effect the user is expected to
+infer. Defaults should preserve user data unless deletion is necessary for a
+disclosed privacy or retention purpose.
+
+Automatic lifecycle deletion, such as removing temporary audio after
+processing, remains appropriate when it is part of the stated privacy design.
+It must be disclosed before collection, applied consistently, and covered by
+tests and operational records rather than presented as a user-initiated action.

--- a/docs/maintainer-principles.md
+++ b/docs/maintainer-principles.md
@@ -84,3 +84,9 @@ Human-centered technology should support longitudinal awareness, informed
 choice, family communication when the individual wants it, and appropriate
 professional follow-up while preserving privacy, agency, and cultural and
 linguistic accessibility.
+
+KinaBot may act as a longitudinal mirror by quantifying the direction,
+magnitude, and variability of defined speech and language features over time
+under a versioned method. A lower or more variable feature value is a
+feature-level observation; it must not be presented as direct evidence of
+cognitive, brain, or neurological decline.

--- a/docs/maintainer-principles.md
+++ b/docs/maintainer-principles.md
@@ -63,3 +63,24 @@ Automatic lifecycle deletion, such as removing temporary audio after
 processing, remains appropriate when it is part of the stated privacy design.
 It must be disclosed before collection, applied consistently, and covered by
 tests and operational records rather than presented as a user-initiated action.
+
+## 8. Dignity Through Access and Awareness
+
+**Documented:** 2026-08-05
+
+**Scope:** AImoji product purpose, access, and evidence boundaries
+
+People should have a fair opportunity to notice and understand meaningful
+patterns in their health and everyday functioning, and to decide when to seek
+support. Access to understandable information and appropriate evaluation should
+not depend on income, insurance status, race, language, or geography.
+
+AImoji products should reduce informational and practical barriers without
+turning access into overclaiming. They must not present speech-derived patterns
+as direct measurements of the brain or nervous system, replace qualified
+clinical evaluation, or imply that awareness alone is diagnosis.
+
+Human-centered technology should support longitudinal awareness, informed
+choice, family communication when the individual wants it, and appropriate
+professional follow-up while preserving privacy, agency, and cultural and
+linguistic accessibility.


### PR DESCRIPTION
## What changed

- records Aoi's original data-loss transparency principle
- records **Dignity Through Access and Awareness** as an AImoji product principle
- defines KinaBot as a longitudinal mirror for feature direction, magnitude, and variability—not a medical, brain, or neurological measurement
- publishes two evidence-linked learning cases for global students and product builders
- links the cases into the Product Learning Archive, Evidence Map, Open Curriculum, and Journey Timeline

## Why

Human-centered technology should make destructive consequences explicit and reduce inequitable barriers to understandable longitudinal information. It must do so without replacing clinical evaluation, weakening privacy, or converting feature-level observations into unsupported health claims.

## Claims boundary

A lower or more variable speech/language feature is not presented as cognitive decline or evidence of a brain or neurological disorder. The access case documents Aoi's professional observation and product motivation, not a prevalence study, clinical outcome, or legal human-rights determination.

## Validation

- `git diff --check`
- internal Markdown link validation: 0 missing links
- documentation-only changes