### PR TITLE
Add offline/private research API for university integration

### DIFF
--- a/aoi_kinabot_app/CHANGELOG.md
+++ b/aoi_kinabot_app/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2026-08-10 · Offline/private research API
+
+- Added a dedicated localhost-only FastAPI subsystem so approved university
+  software can call the existing KinaBot engine without internet or cloud AI.
+- Added local token authentication, study-secret participant pseudonyms,
+  request size/type validation, versioned analysis responses, history, and
+  explicit participant-data deletion.
+- Removed `OPENAI_API_KEY` at API launch; offline calls create no OpenAI usage
+  or AImoji per-request API expense.
+- Added one-command Windows startup, generated local API credentials, OpenAPI
+  documentation, administrator guidance, commercial/claims boundaries, and
+  evidence-preservation guidance.
+- Verified the change with 27 passing multilingual, offline, privacy, and API
+  tests; this is engineering verification, not institutional or clinical
+  validation.
+
 ## 2026-08-06 · Dated learning case library
 
 - Established a publication standard and reusable template for meaningful,

--- a/aoi_kinabot_app/OFFLINE-QUICKSTART.md
+++ b/aoi_kinabot_app/OFFLINE-QUICKSTART.md
@@ -14,6 +14,12 @@
 7. Run `.\run-offline.ps1`.
 8. Open `http://127.0.0.1:8501`.
 
+If approved university software will call KinaBot directly, run
+`.\offline_api\run-offline-api.ps1` instead and open
+`http://127.0.0.1:8787/docs`. See the
+[Offline/Private Research API guide](offline_api/README.md). The local API uses
+the same analysis engine and database; it does not call OpenAI.
+
 ## For a Participant
 
 1. Enter the ID assigned by the university, for example `001`.

--- a/aoi_kinabot_app/README.md
+++ b/aoi_kinabot_app/README.md
@@ -83,6 +83,11 @@ should also review the [offline research guide](docs/OFFLINE-RESEARCH-GUIDE.md),
 [UK/EU data-protection readiness checklist](docs/UK-EU-DATA-PROTECTION-READINESS.md),
 and [bundle manifest](docs/OFFLINE-BUNDLE-MANIFEST.md).
 
+Approved local software can integrate through the
+[Offline/Private Research API](offline_api/README.md). It listens on localhost,
+uses the same KinaBot scoring engine and local study data, requires a local
+token, and does not call OpenAI.
+
 Offline engineering controls support—but do not replace—university ethics,
 information-governance, legal, security, and study-protocol approval.
 

--- a/aoi_kinabot_app/config.py
+++ b/aoi_kinabot_app/config.py
@@ -21,6 +21,7 @@ ALLOW_LOCAL_VERIFICATION_CODES = (
     and not OFFLINE_RESEARCH_MODE
 )
 ADMIN_KEY = os.getenv("KINABOT_ADMIN_KEY", "").strip()
+LOCAL_API_TOKEN = os.getenv("KINABOT_LOCAL_API_TOKEN", "").strip()
 
 APP_DIR = Path(__file__).resolve().parent
 DATA_DIR = APP_DIR / "data"

--- a/aoi_kinabot_app/database.py
+++ b/aoi_kinabot_app/database.py
@@ -138,6 +138,39 @@ def upsert_user(email_hash: str, email: str | None = None) -> int:
         return int(row["id"])
 
 
+def find_user_id_by_email_hash(email_hash: str) -> int | None:
+    """Resolve a pseudonymous key without creating a participant record."""
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT id FROM users WHERE email_hash = ?", (email_hash,)
+        ).fetchone()
+        return int(row["id"]) if row else None
+
+
+def delete_user_research_data(user_id: int) -> bool:
+    """Delete one participant's local records in an explicit transaction."""
+    with get_connection() as conn:
+        if not conn.execute("SELECT 1 FROM users WHERE id = ?", (user_id,)).fetchone():
+            return False
+        session_ids = [
+            int(row["id"])
+            for row in conn.execute(
+                "SELECT id FROM test_sessions WHERE user_id = ?", (user_id,)
+            ).fetchall()
+        ]
+        if session_ids:
+            placeholders = ",".join("?" for _ in session_ids)
+            conn.execute(
+                f"DELETE FROM feature_scores WHERE test_session_id IN ({placeholders})",
+                session_ids,
+            )
+        conn.execute("DELETE FROM habit_checkins WHERE user_id = ?", (user_id,))
+        conn.execute("DELETE FROM consent_events WHERE user_id = ?", (user_id,))
+        conn.execute("DELETE FROM test_sessions WHERE user_id = ?", (user_id,))
+        conn.execute("DELETE FROM users WHERE id = ?", (user_id,))
+        return True
+
+
 def get_user_profile(user_id: int) -> sqlite3.Row | None:
     with get_connection() as conn:
         return conn.execute(
@@ -364,6 +397,10 @@ def get_user_scores(user_id: int) -> list[sqlite3.Row]:
                 ts.session_number,
                 ts.session_type,
                 ts.language,
+                ts.duration_seconds,
+                ts.app_version,
+                ts.consent_version,
+                ts.scoring_model_version,
                 fs.feature_name,
                 fs.score
             FROM feature_scores fs

--- a/aoi_kinabot_app/docs/OFFLINE-BUNDLE-MANIFEST.md
+++ b/aoi_kinabot_app/docs/OFFLINE-BUNDLE-MANIFEST.md
@@ -11,6 +11,8 @@ Every university delivery must identify:
 - build date and builder;
 - institution and approved research purpose;
 - offline acceptance-test result;
+- enabled interface (`Streamlit UI`, `Local Research API`, or both) and its
+  approved localhost port;
 - known limitations; and
 - contact for security or data-protection issues.
 
@@ -18,5 +20,6 @@ Every university delivery must identify:
 an approved wheelhouse and model directory. `verify-offline-bundle.ps1` checks
 that required components exist and that every manifested file is unchanged.
 
-The generated bundle, model, wheelhouse, participant-key secret, databases, and
-research exports must not be committed to the public repository.
+The generated bundle, model, wheelhouse, participant-key secret, local API
+token, databases, and research exports must not be committed to the public
+repository.

--- a/aoi_kinabot_app/docs/README.md
+++ b/aoi_kinabot_app/docs/README.md
@@ -17,6 +17,7 @@ what a voice sample can prove.
 - [AI Risk Register](AI-RISK-REGISTER.md)
 - [Impact Metrics and Evidence Rules](IMPACT-METRICS.md)
 - [Offline Research Mode](OFFLINE-RESEARCH-GUIDE.md)
+- [Offline/Private Research API](../offline_api/README.md)
 - [Offline Bundle Manifest](OFFLINE-BUNDLE-MANIFEST.md)
 - [UK/EU Data-Protection Readiness](UK-EU-DATA-PROTECTION-READINESS.md)
 - [Decision Log](DECISION-LOG.md)

--- a/aoi_kinabot_app/docs/learning-cases/EVIDENCE-MAP.md
+++ b/aoi_kinabot_app/docs/learning-cases/EVIDENCE-MAP.md
@@ -24,6 +24,7 @@ field-wide significance.
 | Offline research mode | [`5a23963`](https://github.com/usekina/kina/commit/5a23963) | [PR #29](https://github.com/usekina/kina/pull/29) and [Offline Research Guide](../OFFLINE-RESEARCH-GUIDE.md) |
 | Explicit controls for data-loss actions | [`386bf0f`](https://github.com/usekina/kina/commit/386bf0f) | [AImoji Maintainer Principles](../../../docs/maintainer-principles.md) |
 | Dignity through equitable access and longitudinal awareness | [`2075664`](https://github.com/usekina/kina/commit/2075664) | [AImoji Maintainer Principles](../../../docs/maintainer-principles.md) |
+| Local/private research API and university interoperability | [`6e2457e`](https://github.com/usekina/kina/commit/6e2457e) | [PR #32](https://github.com/usekina/kina/pull/32), [API guide](../../offline_api/README.md), and [dated learning case](aoi-maintained-product/2026-08-10-local-api-for-private-research.md) |
 
 ## Authorship Boundary
 

--- a/aoi_kinabot_app/docs/learning-cases/JOURNEY-TIMELINE.md
+++ b/aoi_kinabot_app/docs/learning-cases/JOURNEY-TIMELINE.md
@@ -109,6 +109,17 @@ implemented behavior, and future goals.
 - **Takeaway:** continuous contribution becomes more useful when others can
   inspect and learn from the reasoning, including mistakes and uncertainty.
 
+## 2026-08-10 · Private Research Interoperability
+
+- A UK university use context led Aoi to extend offline KinaBot from a
+  standalone interface into a localhost-only, authenticated research API.
+- The API reused the local multilingual scoring authority, converted research
+  IDs into study-secret pseudonyms, removed OpenAI at launch, exposed deletion,
+  and returned limitations and version provenance in every result.
+- **Takeaway:** interoperability for sensitive data should distribute useful
+  capability without distributing identity, transcripts, diagnostic claims, or
+  an external-service dependency.
+
 ## Evidence Frontier
 
 The next milestones are not yet achievements: real pilots, representative user

--- a/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-08-10-local-api-for-private-research.md
+++ b/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-08-10-local-api-for-private-research.md
@@ -1,0 +1,110 @@
+# From an Offline App to a Private Research Capability
+
+**Date:** 2026-08-10
+
+**Maintained product:** `aoi_kinabot_app/`
+
+**Product direction and decision owner:** Aoi Minamoto, AImoji LLC
+
+**Evidence status:** implemented and automatically tested on the feature branch;
+external university use and impact remain to be independently documented.
+
+## Context
+
+After an earlier request for offline KinaBot use, a UK university researcher
+reported that an intern would use a Windows 11 university PC with an Intel i7.
+The computer was not fully air-gapped, but the research context still required
+a design that did not depend on email, cloud transcription, or external AI.
+
+Aoi then asked whether another application could run KinaBot through an API.
+The requirement was not merely machine-to-machine access. The integration had
+to preserve KinaBot's dignity-first, non-diagnostic, privacy-aware,
+longitudinal product boundary.
+
+## Aoi's Product and Engineering Decisions
+
+Aoi established that the university team should receive a practical, local
+integration capability rather than a cloud dependency. She required that the
+work be independently packaged, easy for a research team to operate, and
+recorded as a high-quality engineering contribution.
+
+The resulting decisions were:
+
+1. Create a dedicated `offline_api/` subsystem while reusing KinaBot's existing
+   transcription, multilingual analysis, scoring, identity, and database
+   modules. This avoids a second, inconsistent scoring authority.
+2. Bind the service to `127.0.0.1` by default. A local API does not need to
+   become an internet service.
+3. Require a locally generated research token for participant-data operations.
+4. Convert a school ID such as `001` immediately into a study-secret HMAC
+   pseudonym and never return or store the raw ID.
+5. Remove `OPENAI_API_KEY` during startup and use only preinstalled local
+   Whisper plus KinaBot scoring. University use therefore does not consume
+   Aoi's OpenAI account or create an AImoji per-request API bill.
+6. Return scoring and application provenance, retention behavior, `self_only`
+   comparison scope, and `non_diagnostic: true` as part of the API contract.
+7. Add an explicit participant deletion operation.
+8. Preserve the distinction between engineering verification and claims of
+   clinical validity, legal compliance, institutional approval, or impact.
+
+## Why a Simple Cloud Endpoint Was Rejected
+
+Sending university recordings to a public endpoint would introduce a new data
+transfer, internet dependency, account relationship, availability risk, and
+cost boundary. It would also weaken the earlier offline design. A local-only
+API lets approved software integrate while raw data and computation remain on
+the research computer.
+
+## Implemented Evidence
+
+- `offline_api/api.py`: FastAPI surface, authorization, file limits, health,
+  analysis, history, and deletion endpoints.
+- `offline_api/service.py`: reuse of the authoritative pipeline, HMAC identity,
+  consent recording, versioned persistence, and non-diagnostic contract.
+- `offline_api/run-offline-api.ps1`: localhost startup, local secrets, local
+  Whisper, local database, and explicit OpenAI-key removal.
+- `database.py`: pseudonymous lookup without accidental participant creation
+  and deletion of participant records.
+- `offline_api/tests/test_api.py`: authorization, non-disclosure, provenance,
+  deletion, ID validation, and file-type tests.
+- `offline_api/README.md`: installation, API, expense and governance boundaries,
+  verification, and pilot-evidence guidance.
+
+At implementation time, 27 automated tests passed: 18 existing multilingual
+tests, six existing offline-mode tests, and three new API scenarios. The exact
+result should be re-established by CI for the final commit.
+
+## Human-Centered Significance
+
+Interoperability can widen access, but it can also distribute risk. Treating
+privacy, identity, deletion, interpretation limits, and provenance as part of
+the interface means another application cannot integrate only the attractive
+scores while silently omitting their intended meaning. The API turns the
+dignity-first boundary into a machine-readable product contract.
+
+## Business and Sustainability Lesson
+
+No OpenAI bill does not mean no product value. The reusable value includes the
+longitudinal method, multilingual engine, privacy architecture, validated
+bundle, integration support, training, maintenance, institutional deployment,
+and future partner services. A limited pilot does not commit AImoji to free
+production support or permanent commercial rights.
+
+## Claims Boundary and Next Evidence
+
+This repository establishes dated implementation, reasoning, maintainership,
+and automated engineering verification. It does not yet prove university
+installation or adoption, participant benefit, clinical validity, or
+field-wide impact.
+
+Those claims require independent records: university acceptance, approved
+study documents, deployment checksum, aggregate use, external feedback,
+validation, publications, citations, continued adoption, and recognition.
+Participant data and confidential correspondence must remain outside GitHub.
+
+## Practical Takeaway
+
+An offline API is not a contradiction. It is a stable software contract inside
+a controlled environment. For sensitive human data, the strongest API may be
+the one that gives other applications interoperability without giving the
+internet the data.

--- a/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/README.md
+++ b/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/README.md
@@ -17,6 +17,7 @@ governance, and offline research mode.
 - [From Online Product to Offline University Research](2026-08-05-offline-university-research.md)
 - [Users Must Never Have to Guess About Data Loss](2026-08-05-explicit-data-loss-controls.md)
 - [Dignity Through Access and Awareness](2026-08-05-dignity-through-access-awareness.md)
+- [From an Offline App to a Private Research Capability](2026-08-10-local-api-for-private-research.md)
 
 ## Reading Boundary
 

--- a/aoi_kinabot_app/install-offline.ps1
+++ b/aoi_kinabot_app/install-offline.ps1
@@ -8,6 +8,7 @@ $wheelhouse = Join-Path $appRoot "wheelhouse"
 $modelPath = Join-Path $appRoot "models\whisper-small"
 $venvPython = Join-Path $appRoot ".venv\Scripts\python.exe"
 $secretPath = Join-Path $appRoot ".offline-participant-key"
+$apiTokenPath = Join-Path $appRoot ".offline-api-token"
 
 if (-not (Test-Path -LiteralPath $wheelhouse -PathType Container)) {
     throw "Missing wheelhouse. Ask the package administrator for the complete offline bundle."
@@ -31,5 +32,16 @@ if (-not (Test-Path -LiteralPath $secretPath -PathType Leaf)) {
     )
 }
 
+if (-not (Test-Path -LiteralPath $apiTokenPath -PathType Leaf)) {
+    $bytes = New-Object byte[] 48
+    [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+    [System.IO.File]::WriteAllText(
+        $apiTokenPath,
+        [Convert]::ToBase64String($bytes),
+        [System.Text.UTF8Encoding]::new($false)
+    )
+}
+
 Write-Host "KinaBot offline installation completed."
 Write-Host "Run .\run-offline.ps1 to start."
+Write-Host "Run .\offline_api\run-offline-api.ps1 for local software integration."

--- a/aoi_kinabot_app/offline_api/README.md
+++ b/aoi_kinabot_app/offline_api/README.md
@@ -1,0 +1,133 @@
+# KinaBot Offline/Private Research API
+
+This package lets approved university software call KinaBot on the same Windows
+computer without internet, email, cloud transcription, or OpenAI. It is an
+integration surface for the existing versioned KinaBot feature engine—not a
+second scoring implementation and not a diagnostic API.
+
+## Trust Boundary
+
+- Binds to `127.0.0.1` by default; it is not exposed to the campus network.
+- Requires a locally generated `X-KinaBot-Token` for every data operation.
+- Converts a university-assigned ID into a study-secret HMAC pseudonym. The raw
+  ID is not stored or returned.
+- Uses the preinstalled local `faster-whisper` model and KinaBot's multilingual
+  Python/NLP scoring.
+- Deletes temporary audio on success and failure; does not persist full
+  transcripts.
+- Removes `OPENAI_API_KEY` at launch. Calls create no OpenAI usage or AImoji API
+  bill.
+- Returns versions, retention statements, self-comparison scope, and an
+  explicit non-diagnostic boundary with every analysis.
+
+These controls support but do not replace university ethics, information
+governance, legal, accessibility, security, and study-protocol approval.
+
+## Administrator Quick Start
+
+Use the complete approved offline bundle. From `aoi_kinabot_app`:
+
+```powershell
+.\install-offline.ps1
+.\offline_api\run-offline-api.ps1
+```
+
+Open `http://127.0.0.1:8787/docs` for the generated OpenAPI interface and
+`http://127.0.0.1:8787/health` for readiness. The calling application reads the
+local token from `.offline-api-token`; keep that file on the encrypted research
+computer and never email it, commit it, or include it in screenshots.
+
+The API and Streamlit research UI use the same database by default. Run only
+the surfaces approved by the study protocol.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/health` | Local readiness and version metadata; no participant data |
+| `POST` | `/v1/reflections` | Transcribe and calculate one descriptive feature set |
+| `GET` | `/v1/participants/{id}/history` | Return that participant's derived longitudinal observations |
+| `DELETE` | `/v1/participants/{id}` | Delete that participant's local derived record |
+
+Example PowerShell request:
+
+```powershell
+$token = (Get-Content .\.offline-api-token -Raw).Trim()
+$headers = @{ "X-KinaBot-Token" = $token }
+$form = @{
+    participant_id = "001"
+    language = "English"
+    consent_version = "approved-study-consent-v1"
+    session_type = "weekly-reflection"
+    audio = Get-Item "C:\approved-study-input\sample.wav"
+}
+Invoke-RestMethod -Method Post -Uri "http://127.0.0.1:8787/v1/reflections" `
+    -Headers $headers -Form $form
+```
+
+Supported language values are `English`, `日本語`, and `中文`. Supported local
+transcription formats are MP3, MP4, MPEG, MPGA, M4A, WAV, and WEBM.
+
+## Response Contract
+
+An analysis contains feature evidence plus:
+
+```json
+{
+  "provenance": {
+    "app_version": "v1.2-offline-research",
+    "scoring_version": "score-v2-multilingual",
+    "transcription": "local-faster-whisper"
+  },
+  "interpretation": {
+    "comparison_scope": "self_only",
+    "non_diagnostic": true
+  },
+  "retention": {
+    "audio": "ephemeral",
+    "full_transcript": "not_stored"
+  }
+}
+```
+
+Clients must preserve these limitations when presenting results. They must not
+rename a feature as a diagnosis, disease screen, clinical measurement, or risk.
+
+## Expense and Commercial Boundary
+
+Offline use does not consume an OpenAI API key and has no per-request OpenAI
+charge. The institution supplies its computer, storage, electricity, IT
+support, and approved local model bundle. Open-source availability does not
+promise free deployment, customization, validation, training, maintenance, or
+future institutional service. Those require a separate written agreement where
+applicable. Repository licensing and commercial terms should be reviewed before
+any production or redistribution commitment.
+
+## Verification
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q `
+    test_multilingual.py test_offline_mode.py offline_api\tests
+```
+
+The tests cover authorization, pseudonymization boundaries, non-retention in
+responses, version provenance, deletion, invalid IDs, unsupported files, and
+the existing multilingual/offline behavior. They establish engineering
+behavior—not clinical validity, legal compliance, institutional approval, or
+real-world effectiveness.
+
+## Pilot Evidence to Preserve
+
+With participant consent and university approval, preserve non-sensitive proof
+of institutional evaluation separately from participant data:
+
+- dated installation and acceptance record;
+- approved study protocol/version and institutional contact;
+- software commit and bundle checksum used;
+- number of completed sessions in aggregate;
+- usability and integration feedback;
+- defects, resolutions, and validation results; and
+- publication, citation, adoption, or continuation decisions when they occur.
+
+Never place participant audio, transcripts, raw IDs, secrets, private exports,
+or unapproved university correspondence in GitHub.

--- a/aoi_kinabot_app/offline_api/__init__.py
+++ b/aoi_kinabot_app/offline_api/__init__.py
@@ -1,0 +1,1 @@
+"""KinaBot local/private research API package."""

--- a/aoi_kinabot_app/offline_api/api.py
+++ b/aoi_kinabot_app/offline_api/api.py
@@ -1,0 +1,94 @@
+"""Local-only HTTP API for approved offline KinaBot research deployments."""
+
+from __future__ import annotations
+
+import io
+import secrets
+
+from fastapi import Depends, FastAPI, File, Form, Header, HTTPException, UploadFile
+
+from config import (APP_VERSION, LOCAL_API_TOKEN, MAX_AUDIO_BYTES,
+                    OFFLINE_RESEARCH_MODE, SCORING_MODEL_VERSION)
+from offline_api.service import (ResearchServiceError, analyze_reflection,
+                                 erase_participant, participant_history)
+from speech_to_text import LOCAL_TRANSCRIPTION_TYPES, speech_to_text_configured
+
+app = FastAPI(
+    title="KinaBot Offline Research API", version="1.0.0",
+    description=("Local, non-diagnostic speech-reflection API for approved "
+                 "research. Raw audio and full transcripts are not retained."),
+    docs_url="/docs", redoc_url=None,
+)
+
+
+def require_local_token(x_kinabot_token: str = Header(default="")) -> None:
+    if len(LOCAL_API_TOKEN) < 32:
+        raise HTTPException(status_code=503,
+                            detail="Local API token is not configured.")
+    if not secrets.compare_digest(x_kinabot_token, LOCAL_API_TOKEN):
+        raise HTTPException(status_code=401, detail="Invalid local API token.")
+
+
+def require_offline_mode() -> None:
+    if not OFFLINE_RESEARCH_MODE:
+        raise HTTPException(
+            status_code=503,
+            detail="KINABOT_OFFLINE_RESEARCH_MODE=true is required.")
+
+
+protected = [Depends(require_local_token), Depends(require_offline_mode)]
+
+
+@app.get("/health")
+def health() -> dict:
+    ready = OFFLINE_RESEARCH_MODE and speech_to_text_configured()
+    return {"status": "ready" if ready else "not_ready",
+            "offline_mode": OFFLINE_RESEARCH_MODE,
+            "local_transcription_ready": speech_to_text_configured(),
+            "app_version": APP_VERSION,
+            "scoring_version": SCORING_MODEL_VERSION,
+            "non_diagnostic": True}
+
+
+@app.post("/v1/reflections", dependencies=protected)
+async def create_reflection(
+    participant_id: str = Form(...), language: str = Form(...),
+    consent_version: str = Form(...),
+    session_type: str = Form("research-reflection"),
+    audio: UploadFile = File(...),
+) -> dict:
+    extension = (audio.filename or "").rsplit(".", 1)[-1].lower()
+    if extension not in LOCAL_TRANSCRIPTION_TYPES:
+        raise HTTPException(status_code=415, detail="Unsupported audio type.")
+    content = await audio.read(MAX_AUDIO_BYTES + 1)
+    if len(content) > MAX_AUDIO_BYTES:
+        raise HTTPException(status_code=413,
+                            detail="Audio exceeds the configured size limit.")
+    try:
+        return analyze_reflection(
+            participant_id=participant_id, language=language,
+            consent_version=consent_version, audio_file=io.BytesIO(content),
+            filename=audio.filename or "recording.audio",
+            session_type=session_type)
+    except ResearchServiceError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@app.get("/v1/participants/{participant_id}/history", dependencies=protected)
+def get_history(participant_id: str) -> dict:
+    try:
+        return participant_history(participant_id)
+    except ResearchServiceError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@app.delete("/v1/participants/{participant_id}", dependencies=protected)
+def delete_participant(participant_id: str) -> dict:
+    try:
+        deleted = erase_participant(participant_id)
+    except ResearchServiceError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    if not deleted:
+        raise HTTPException(status_code=404,
+                            detail="Participant record not found.")
+    return {"deleted": True}

--- a/aoi_kinabot_app/offline_api/run-offline-api.ps1
+++ b/aoi_kinabot_app/offline_api/run-offline-api.ps1
@@ -1,0 +1,34 @@
+param(
+    [string]$WhisperModelPath = "$PSScriptRoot\..\models\whisper-small",
+    [string]$DatabasePath = "$PSScriptRoot\..\data\kinabot_offline.sqlite3",
+    [int]$Port = 8787
+)
+
+$ErrorActionPreference = "Stop"
+$appRoot = Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..")
+$python = Join-Path $appRoot.Path ".venv\Scripts\python.exe"
+$participantSecret = Join-Path $appRoot.Path ".offline-participant-key"
+$apiToken = Join-Path $appRoot.Path ".offline-api-token"
+$model = Resolve-Path -LiteralPath $WhisperModelPath -ErrorAction Stop
+foreach ($required in @($python, $participantSecret, $apiToken)) {
+    if (-not (Test-Path -LiteralPath $required -PathType Leaf)) {
+        throw "Offline installation is incomplete. Run .\install-offline.ps1 first."
+    }
+}
+$env:KINABOT_OFFLINE_RESEARCH_MODE = "true"
+$env:KINABOT_OFFLINE_WHISPER_MODEL_PATH = $model.Path
+$env:KINABOT_DATABASE_PATH = $DatabasePath
+$env:KINABOT_ENVIRONMENT = "offline"
+$env:KINABOT_PARTICIPANT_KEY_SECRET = (Get-Content $participantSecret -Raw).Trim()
+$env:KINABOT_LOCAL_API_TOKEN = (Get-Content $apiToken -Raw).Trim()
+$env:KINABOT_ALLOW_LOCAL_CODES = "false"
+Remove-Item Env:OPENAI_API_KEY -ErrorAction SilentlyContinue
+
+Push-Location $appRoot.Path
+try {
+    & $python -m uvicorn offline_api.api:app --host 127.0.0.1 `
+        --port $Port --no-access-log
+}
+finally {
+    Pop-Location
+}

--- a/aoi_kinabot_app/offline_api/service.py
+++ b/aoi_kinabot_app/offline_api/service.py
@@ -1,0 +1,101 @@
+"""Private research orchestration built on KinaBot's authoritative core."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import BinaryIO
+
+from config import (APP_VERSION, MAX_TESTS_PER_DAY, PARTICIPANT_KEY_SECRET,
+                    SCORING_MODEL_VERSION)
+from database import (
+    count_tests_today, create_test_session, delete_user_research_data,
+    find_user_id_by_email_hash, get_user_scores, init_db, record_consent,
+    save_feature_scores, upsert_user,
+)
+from language_analysis import LANGUAGE_CODES, analyze_transcript
+from offline_identity import participant_key
+from speech_to_text import transcribe_audio_upload
+
+NON_DIAGNOSTIC_BOUNDARY = (
+    "Descriptive features for this recording only. They do not indicate health, "
+    "ability, improvement, decline, diagnosis, cause, or risk."
+)
+
+
+class ResearchServiceError(ValueError):
+    """Expected input or processing failure safe to return to a local client."""
+
+
+def _participant_context(participant_id: str) -> tuple[str, int | None]:
+    if len(PARTICIPANT_KEY_SECRET) < 32:
+        raise ResearchServiceError(
+            "KINABOT_PARTICIPANT_KEY_SECRET must contain at least 32 characters."
+        )
+    try:
+        key = participant_key(participant_id, PARTICIPANT_KEY_SECRET)
+    except ValueError as exc:
+        raise ResearchServiceError(str(exc)) from exc
+    return key, find_user_id_by_email_hash(key)
+
+
+def analyze_reflection(*, participant_id: str, language: str,
+                       consent_version: str, audio_file: BinaryIO,
+                       filename: str,
+                       session_type: str = "research-reflection") -> dict:
+    """Transcribe and score while retaining only pseudonymous derived data."""
+    if language not in LANGUAGE_CODES:
+        raise ResearchServiceError("Language must be English, 日本語, or 中文.")
+    if not consent_version.strip() or len(consent_version) > 100:
+        raise ResearchServiceError("A valid consent_version is required.")
+    init_db()
+    key, user_id = _participant_context(participant_id)
+    today = datetime.now(timezone.utc).date().isoformat()
+    if user_id is not None and count_tests_today(user_id, today) >= MAX_TESTS_PER_DAY:
+        raise ResearchServiceError("Daily reflection limit reached.")
+    ok, transcript_or_error, duration, acoustic_metrics = transcribe_audio_upload(
+        audio_file, filename, LANGUAGE_CODES[language]
+    )
+    if not ok:
+        raise ResearchServiceError(transcript_or_error)
+    scores, summary = analyze_transcript(
+        transcript_or_error, language, duration, acoustic_metrics
+    )
+    user_id = user_id or upsert_user(key, email=None)
+    record_consent(user_id, consent_version.strip())
+    session_number = count_tests_today(user_id, today) + 1
+    session_id = create_test_session(
+        user_id=user_id, session_date=today, session_number=session_number,
+        app_version=APP_VERSION, consent_version=consent_version.strip(),
+        scoring_model_version=SCORING_MODEL_VERSION,
+        session_type=session_type.strip()[:100] or "research-reflection",
+        language=language, duration_seconds=duration, timezone_name="UTC",
+    )
+    save_feature_scores(session_id, scores)
+    return {
+        "analysis_id": f"session-{session_id}", "session_number": session_number,
+        "language": language, "duration_seconds": duration, "summary": summary,
+        "features": scores,
+        "provenance": {"app_version": APP_VERSION,
+                       "scoring_version": SCORING_MODEL_VERSION,
+                       "transcription": "local-faster-whisper"},
+        "interpretation": {"type": "longitudinal_reflection",
+                           "comparison_scope": "self_only",
+                           "non_diagnostic": True,
+                           "boundary": NON_DIAGNOSTIC_BOUNDARY},
+        "retention": {"audio": "ephemeral", "full_transcript": "not_stored"},
+    }
+
+
+def participant_history(participant_id: str) -> dict:
+    """Return derived observations without returning the raw participant ID."""
+    _, user_id = _participant_context(participant_id)
+    rows = [] if user_id is None else [dict(row) for row in get_user_scores(user_id)]
+    return {"sessions": rows,
+            "session_count": len({row["session_id"] for row in rows}),
+            "comparison_scope": "self_only", "non_diagnostic": True}
+
+
+def erase_participant(participant_id: str) -> bool:
+    """Erase one participant's pseudonymous local research record."""
+    _, user_id = _participant_context(participant_id)
+    return False if user_id is None else delete_user_research_data(user_id)

--- a/aoi_kinabot_app/offline_api/tests/test_api.py
+++ b/aoi_kinabot_app/offline_api/tests/test_api.py
@@ -1,0 +1,79 @@
+import importlib
+import io
+
+import pytest
+from fastapi.testclient import TestClient
+
+TEST_SECRET = "test-participant-secret-that-is-at-least-32-characters"
+TEST_TOKEN = "test-local-api-token-that-is-at-least-32-characters"
+
+
+@pytest.fixture()
+def api(tmp_path, monkeypatch):
+    monkeypatch.setenv("KINABOT_OFFLINE_RESEARCH_MODE", "true")
+    monkeypatch.setenv("KINABOT_PARTICIPANT_KEY_SECRET", TEST_SECRET)
+    monkeypatch.setenv("KINABOT_LOCAL_API_TOKEN", TEST_TOKEN)
+    monkeypatch.setenv("KINABOT_DATABASE_PATH", str(tmp_path / "research.sqlite3"))
+    import config
+    import database
+    import offline_api.service as service
+    import offline_api.api as api_module
+    importlib.reload(config)
+    importlib.reload(database)
+    importlib.reload(service)
+    importlib.reload(api_module)
+    return api_module, service, TestClient(api_module.app)
+
+
+def test_data_endpoints_require_token(api):
+    _, _, client = api
+    assert client.get("/v1/participants/001/history").status_code == 401
+
+
+def test_reflection_is_pseudonymous_versioned_and_deletable(api, monkeypatch):
+    _, service, client = api
+
+    def fake_transcription(audio_file, filename, language_code):
+        assert audio_file.read() == b"not-real-audio"
+        return True, "I spoke with my family today.", 8.0, {"pause_ratio": 0.1}
+
+    monkeypatch.setattr(service, "transcribe_audio_upload", fake_transcription)
+    headers = {"X-KinaBot-Token": TEST_TOKEN}
+    response = client.post(
+        "/v1/reflections", headers=headers,
+        data={"participant_id": "001", "language": "English",
+              "consent_version": "study-consent-2026-01"},
+        files={"audio": ("sample.wav", io.BytesIO(b"not-real-audio"), "audio/wav")},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["interpretation"]["non_diagnostic"] is True
+    assert body["retention"] == {"audio": "ephemeral",
+                                  "full_transcript": "not_stored"}
+    assert body["provenance"]["scoring_version"]
+    assert "001" not in response.text
+    assert "family" not in response.text
+
+    history = client.get("/v1/participants/001/history", headers=headers)
+    assert history.status_code == 200
+    assert history.json()["session_count"] == 1
+    assert "001" not in history.text
+
+    assert client.delete("/v1/participants/001", headers=headers).status_code == 200
+    empty = client.get("/v1/participants/001/history", headers=headers)
+    assert empty.json()["session_count"] == 0
+
+
+def test_rejects_invalid_id_and_unsupported_audio(api):
+    _, _, client = api
+    headers = {"X-KinaBot-Token": TEST_TOKEN}
+    unsupported = client.post(
+        "/v1/reflections", headers=headers,
+        data={"participant_id": "001", "language": "English",
+              "consent_version": "study-v1"},
+        files={"audio": ("sample.exe", b"x", "application/octet-stream")},
+    )
+    assert unsupported.status_code == 415
+
+    history = client.get("/v1/participants/not valid/history", headers=headers)
+    assert history.status_code == 422

--- a/aoi_kinabot_app/requirements-offline.txt
+++ b/aoi_kinabot_app/requirements-offline.txt
@@ -5,3 +5,7 @@ jieba>=0.42.1
 janome>=0.5.0
 tzdata>=2026.1
 pytest>=8.0.0
+fastapi>=0.115.0
+uvicorn[standard]>=0.34.0
+python-multipart>=0.0.20
+httpx>=0.28.0


### PR DESCRIPTION
## What changed

- Added a dedicated offline/private FastAPI subsystem for approved software on the same research computer.
- Reused KinaBot's existing local Whisper, multilingual NLP, scoring, HMAC identity, and SQLite modules.
- Added localhost-only startup, generated local-token authentication, file controls, history, and explicit participant deletion.
- Added version, retention, self-comparison, and non-diagnostic fields to the API contract.
- Removed OPENAI_API_KEY at launch, so offline calls do not create AImoji OpenAI usage expense.
- Added administrator, commercial-boundary, pilot-evidence, changelog, timeline, and dated engineering records.

## Why

A UK university research context needs another local application to use KinaBot without email, public internet services, cloud transcription, or stored raw participant IDs.

## Validation

- 27 tests passed across multilingual, offline, privacy, and API behavior.
- Python compilation completed successfully.
- PowerShell parser checks passed.
- git diff --check passed.
- Credential-pattern scan found no committed secrets.

## Claims boundary

These checks establish engineering behavior, not university approval or adoption, legal compliance, clinical validity, participant benefit, or field-wide impact. Those require independent evidence. No participant data or confidential correspondence belongs in GitHub.