### PR TITLE
Add responsible feature interpretation learning case

### DIFF
--- a/aoi_kinabot_app/docs/learning-cases/README.md
+++ b/aoi_kinabot_app/docs/learning-cases/README.md
@@ -129,6 +129,7 @@ all meaningful milestones. The cases below examine the largest learning turns.
 - [2026-08-05 · From Online Product to Offline University Research](aoi-maintained-product/2026-08-05-offline-university-research.md)
 - [2026-08-05 · Users Must Never Have to Guess About Data Loss](aoi-maintained-product/2026-08-05-explicit-data-loss-controls.md)
 - [2026-08-05 · Dignity Through Access and Awareness](aoi-maintained-product/2026-08-05-dignity-through-access-awareness.md)
+- [2026-08-12 · From Feature Variation to Responsible Interpretation](aoi-maintained-product/2026-08-12-feature-variation-responsible-interpretation.md)
 
 ## The Next Cases Must Be Earned
 

--- a/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-08-12-feature-variation-responsible-interpretation.md
+++ b/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/2026-08-12-feature-variation-responsible-interpretation.md
@@ -1,0 +1,122 @@
+# From Feature Variation to Responsible Interpretation
+
+**Date:** 2026-08-12  
+**Status:** Public learning case based on an early descriptive product-data review  
+**Audience:** Students, researchers, product builders, designers, and responsible-AI teams
+
+## Why this case exists
+
+An early KinaBot product export contained pseudonymous participant identifiers, age groups, repeated sessions, observable speech and language features, and feature scores. This created a practical question that appears in many real products:
+
+> If a system records feature changes over time and also contains age-group information, does it know the cognitive status of its users?
+
+The answer is no. The dataset can support a descriptive analysis of observed feature variation. It cannot, by itself, establish cognitive status, cognitive decline, health improvement, disease, or clinical validity.
+
+This distinction is both a data-science requirement and a dignity-first product principle. People should not be given health labels that the evidence cannot support.
+
+## The defensible statement
+
+> KinaBot can measure longitudinal variation in observable speech and language features within the same participant and explore whether those variation patterns differ descriptively across age groups.
+
+This statement describes what was recorded without assigning an unsupported medical meaning to it.
+
+## Three layers that must not be collapsed
+
+1. **Recorded observation** — a feature value was produced for a particular session under a particular software version.
+2. **Descriptive pattern** — the value increased, decreased, or fluctuated across recorded sessions.
+3. **Validated interpretation** — independent evidence establishes what that pattern means for health or cognition.
+
+A common product failure is to jump from Layer 1 or Layer 2 directly to Layer 3. A responsible system preserves the observations while making uncertainty and validation status visible.
+
+## Why the same score change can have different explanations
+
+Observable speech variation may be affected by:
+
+- recording duration, topic, and task difficulty;
+- fatigue, sleep, stress, emotion, pain, medication, and motivation;
+- background noise, microphone position, device, and network conditions;
+- language structure and transcription error;
+- speaking less, pausing more, restarting a sentence, or changing conversational style;
+- scoring, transcription, or analysis-engine version changes.
+
+The early data also had small, non-representative age groups and no paired validated cognitive assessment or clinical evaluation. Therefore, an age-group chart is a description of this product sample—not a population estimate and not a measure of age-group cognition.
+
+## Product and engineering consequences
+
+A responsible longitudinal product should:
+
+- preserve analysis-engine, scoring, transcription, and model versions;
+- retain provenance for each derived feature without exposing unnecessary identity data;
+- separate within-person longitudinal analysis from between-group comparison;
+- define minimum recording and audio-quality eligibility rules;
+- disclose sample size, missingness, exclusions, and uncertainty;
+- suppress or combine very small groups where re-identification is possible;
+- examine language, device, and recording-condition effects before comparing groups;
+- treat repeat use as engagement, not proof of benefit;
+- prohibit diagnostic labels unless the intended use and evidence support them;
+- make deletion, consent, and research-use boundaries understandable to users.
+
+Pseudonymization is not the same as anonymity. Repeated sessions combined with age, language, location, or timestamps may increase re-identification risk. A new health inference is therefore not merely a dashboard feature; it may change the ethical, privacy, legal, validation, and regulatory obligations of the system.
+
+## A validation path before stronger claims
+
+Before interpreting feature variation as evidence about cognition or health, a research program would need to consider:
+
+1. a preregistered question, population, protocol, outcome, and analysis plan;
+2. ethics, consent, information-governance, and security review;
+3. standardized or carefully documented speech tasks and recording conditions;
+4. comparison with an appropriate independently validated assessment;
+5. test-retest reliability and minimum detectable change;
+6. error analysis across languages, devices, and relevant demographic groups;
+7. an adequately sized and representative sample;
+8. independent statistical and domain-expert review;
+9. assessment of the intended-use and regulatory boundary before deployment.
+
+## Dignity-first interpretation
+
+Dignity-first design is not limited to friendly wording or accessible UI. It also governs what conclusions a product is permitted to draw about a person.
+
+The system should help people observe and reflect without turning ordinary variation into pathology. It should explain uncertainty, avoid stigmatizing labels, and enable qualified research without presenting exploratory associations as personal medical facts.
+
+## Classroom exercise: design the analysis before drawing the chart
+
+Using a hypothetical longitudinal speech dataset, prepare a one-page analysis specification containing:
+
+- the unit of analysis;
+- inclusion and audio-quality criteria;
+- the within-person comparison method;
+- possible confounders and how they will be recorded;
+- missing-data and very-small-group rules;
+- one conclusion the data permits;
+- one conclusion the data prohibits;
+- the external evidence required before making a health-related claim.
+
+Then review a proposed age-group dashboard. Identify every visual or label that could cause a reader to confuse product-sample description with clinical interpretation.
+
+## Discussion questions
+
+1. When does a wellness feature begin to create a health inference?
+2. How should a product show longitudinal change without frightening or misleading a user?
+3. Is a statistically significant difference necessarily meaningful to an individual?
+4. What additional risk is created by combining pseudonymous longitudinal data with demographics?
+5. What evidence would convince an independent institution—not only the product creator—that the method is reliable and useful?
+
+## Transferable lesson
+
+> A longitudinal dataset can show that a feature changed. It cannot, by itself, tell us why the feature changed or what the change means for a person's health.
+
+This case can be reused in university data science, human-computer interaction, digital health, responsible AI, product management, and research-methods teaching. It is based on a real product decision, but it does not disclose participant-level records and does not claim health or clinical outcomes.
+
+## Evidence and related materials
+
+- [Early Pilot Impact Report](../../impact-reports/2026-08-11-early-pilot/README.md)
+- [Scoring Methodology](../../../SCORING-METHODOLOGY.md)
+- [Validation Plan](../../VALIDATION-PLAN.md)
+- [Impact Metrics](../../IMPACT-METRICS.md)
+- [Responsible Wellness Design](../../RESPONSIBLE-WELLNESS-DESIGN.md)
+- [AI Risk Register](../../AI-RISK-REGISTER.md)
+- [Observable Features, Not Diagnosis](2026-06-11-observable-features-not-diagnosis.md)
+
+## Claims boundary
+
+This is an educational and product-governance case. It does not establish that KinaBot detects, diagnoses, predicts, prevents, or treats any medical condition, and it does not establish that observed product use caused a health benefit.

--- a/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/README.md
+++ b/aoi_kinabot_app/docs/learning-cases/aoi-maintained-product/README.md
@@ -18,6 +18,7 @@ governance, and offline research mode.
 - [Users Must Never Have to Guess About Data Loss](2026-08-05-explicit-data-loss-controls.md)
 - [Dignity Through Access and Awareness](2026-08-05-dignity-through-access-awareness.md)
 - [From an Offline App to a Private Research Capability](2026-08-10-local-api-for-private-research.md)
+- [From Feature Variation to Responsible Interpretation](2026-08-12-feature-variation-responsible-interpretation.md)
 
 ## Reading Boundary
 


### PR DESCRIPTION
﻿## What changed

- adds a public learning case, **From Feature Variation to Responsible Interpretation**
- explains the boundary between recorded observations, descriptive patterns, and validated health interpretation
- translates a real early-product data question into engineering guidance, a validation pathway, a classroom exercise, and discussion questions
- adds the case to both the Aoi-maintained product index and the global learning-cases index

## Why

Longitudinal feature data can show that an observable feature changed, but it cannot by itself establish why the change occurred or what it means for cognition or health. Recording this distinction as a reusable teaching case extends KinaBot's dignity-first principle from interface design to responsible data interpretation.

## Public and educational impact

The case is designed for university data science, HCI, digital health, responsible AI, product management, and research-methods teaching. It contains no participant-level records and makes no diagnostic or clinical-effect claim.

## Checks

- all local Markdown links resolve
- `git diff --check` passed before commit
- branch contains one case file and two index updates
