### PR TITLE
Add open education and benchmark framework

### DIFF
--- a/aoi_kinabot_app/docs/README.md
+++ b/aoi_kinabot_app/docs/README.md
@@ -28,6 +28,9 @@ what a voice sample can prove.
 - [Mobile-First Results Architecture](ux/MOBILE-FIRST-RESULTS.md)
 - [Product Learning Archive](learning-cases/README.md)
 - [University Offline Research Milestone](education/UNIVERSITY-OFFLINE-RESEARCH-MILESTONE.md)
+- [System Architecture](architecture/SYSTEM-ARCHITECTURE.md)
+- [Benchmark and Evaluation Framework](evaluation/BENCHMARK-FRAMEWORK.md)
+- [Startup-Sponsored Student Project Framework](education/STARTUP-SPONSORED-STUDENT-PROJECT.md)
 
 Technical references remain in the application root:
 

--- a/aoi_kinabot_app/docs/architecture/SYSTEM-ARCHITECTURE.md
+++ b/aoi_kinabot_app/docs/architecture/SYSTEM-ARCHITECTURE.md
@@ -1,0 +1,111 @@
+# KinaBot System Architecture
+
+**Scope:** Aoi-maintained `aoi_kinabot_app/`
+**Purpose:** Public technical reference for builders, reviewers, and students
+
+KinaBot is a dignity-first, multilingual, privacy-aware system for longitudinal
+speech reflection. It describes observable speech and language features; it is
+not a diagnostic system.
+
+## Processing and interpretation architecture
+
+```mermaid
+flowchart LR
+    subgraph U["User-controlled input"]
+        U1["Voice reflection<br/>phone or computer"]
+        U2["English, Japanese, or Chinese"]
+        U3["Consent and context"]
+    end
+    subgraph P["Privacy-aware processing"]
+        P1["Temporary audio copy"]
+        P2["Private or local Whisper<br/>transcription and timestamps"]
+        P3["Delete temporary audio"]
+        P4["Discard full transcript"]
+    end
+    subgraph E["Versioned KinaBot engine"]
+        E1["Language-specific adapter"]
+        E2["Observable feature extraction"]
+        E3["Deterministic scoring"]
+        E4["Version provenance"]
+    end
+    subgraph D["Data-minimized record"]
+        D1["Pseudonymous participant or account"]
+        D2["Session metadata"]
+        D3["Derived metrics and scores"]
+    end
+    subgraph X["Human-centered experience"]
+        X1["Single-session description"]
+        X2["Self-only longitudinal trend"]
+        X3["Review and deletion"]
+    end
+    subgraph B["Evidence boundary"]
+        B1["Recorded observation"]
+        B2["Descriptive pattern"]
+        B3["Validated interpretation"]
+        B4["No diagnosis or cognitive-decline claim"]
+    end
+    U1 --> P1 --> P2 --> E1 --> E2 --> E3 --> E4
+    U2 --> E1
+    U3 --> D1
+    P1 --> P3
+    P2 --> P4
+    E4 --> D2
+    E4 --> D3
+    D2 --> X1
+    D3 --> X1
+    D3 --> X2
+    X1 --> X3
+    X2 --> X3
+    X1 --> B1
+    X2 --> B2
+    B1 --> B2
+    B2 -. "independent evidence required" .-> B3
+    B3 --> B4
+```
+
+The source recording remains under the user's control. KinaBot retains the
+minimum derived record required for the selected deployment and exposes the
+method and version provenance needed to interpret it responsibly.
+
+## Shared core, different trust boundaries
+
+```mermaid
+flowchart TB
+    K["Shared KinaBot core<br/>multilingual feature engine<br/>versioned scoring<br/>claims boundaries"]
+    subgraph O["Online public service"]
+        O1["Verified user access"] --> O2["HTTPS application"]
+        O2 --> O3["Protected persistent storage"]
+        O2 --> O4["Public usage policy"]
+        O3 --> O5["Optional data-minimized insight"]
+    end
+    subgraph R["Offline / Private Research API"]
+        R1["University research ID"] --> R2["Study-secret HMAC pseudonym"]
+        R2 --> R3["Local Windows computer"]
+        R3 --> R4["localhost API"]
+        R4 --> R5["Local Whisper"]
+        R4 --> R6["Protocol-configurable policy"]
+        R5 --> R7["No email, internet, or OpenAI required"]
+    end
+    K --> O
+    K --> R
+```
+
+The offline API is an integration surface for the same versioned engine, not a
+second scoring implementation. Deployment changes identity, network, storage,
+and governance requirements; it does not change the evidence boundary.
+
+## Responsibility boundary
+
+| Responsibility | System owner |
+|---|---|
+| Speech-to-text | Approved private/local transcription engine |
+| Language processing and feature extraction | KinaBot language adapters |
+| Feature-score calculation | Versioned KinaBot scoring engine |
+| Personal trend calculation | KinaBot application |
+| Optional plain-language action | Data-minimized insight layer or curated fallback |
+| Clinical meaning | Not established by the current system |
+| Study interpretation | Approved protocol and qualified independent review |
+
+Architecture diagrams document intended boundaries; tests and deployment
+records must verify actual behavior. Use the [Benchmark and Evaluation
+Framework](../evaluation/BENCHMARK-FRAMEWORK.md) for structured evaluation.

--- a/aoi_kinabot_app/docs/education/STARTUP-SPONSORED-STUDENT-PROJECT.md
+++ b/aoi_kinabot_app/docs/education/STARTUP-SPONSORED-STUDENT-PROJECT.md
@@ -1,0 +1,87 @@
+# Startup-Sponsored Student Project Framework
+
+**Purpose:** An institution-neutral framework for teaching with a real
+human-centered AI product
+
+KinaBot may be offered by its startup maintainer as a sponsor-provided technical
+platform and real-world product context. Students should evaluate, question,
+test, and improve the system—not confirm a predetermined claim.
+
+## Sponsor-provided resources
+
+Subject to the repository license and a written project agreement, the sponsor
+may provide:
+
+- open-source application and versioned scoring code;
+- Online and Offline/Private Research API documentation;
+- architecture, risk, validation, and benchmark specifications;
+- dated learning cases and decision records;
+- synthetic, public, or properly governed de-identified data;
+- reproducible fixtures, technical office hours, and scoped questions.
+
+No student project should receive production credentials, private exports, raw
+participant identifiers, unapproved recordings, or confidential partner
+communications.
+
+## Recommended learning outcomes
+
+Students should be able to:
+
+1. convert a human need into a testable product or research question;
+2. distinguish observation, descriptive pattern, and validated interpretation;
+3. evaluate multilingual assumptions and recording-condition effects;
+4. verify privacy and retention claims against implementation;
+5. report negative and neutral findings;
+6. connect a recommendation to code, tests, risks, and evidence boundaries.
+
+## Example project tracks
+
+| Track | Deliverable |
+|---|---|
+| Multilingual reliability | Language-stratified benchmark with limitations |
+| Longitudinal variation | Protocol separating within-person change from recording noise |
+| Private deployment | Offline API security, retention, deletion, and usability evaluation |
+| Dignity-first UX | Comprehension study for result language and claims boundaries |
+| Responsible access | Evidence-based evaluation of quota, retry, and failure behavior |
+| Reproducibility | Versioned toolkit using synthetic or approved fixtures |
+
+## Independence and student protection
+
+- Students are not free labor for the sponsor.
+- Assessment is controlled by the academic institution, not the sponsor.
+- Negative results and criticism are valid outcomes.
+- Participation, authorship, attribution, intellectual property,
+  confidentiality, publication review, and reuse must be agreed in advance.
+- Student contributions must be credited precisely; sponsor history and student
+  work must not be conflated.
+- Accessibility, workload, safety, privacy, and conflicts of interest require
+  institutional review.
+- Human-participant activity requires applicable ethics and
+  information-governance approval before recruitment or data collection.
+
+## Suggested sponsor statement
+
+> KinaBot is a sponsor-provided, open-source technical platform and real-world
+> product context for student investigation. Students are expected to evaluate,
+> test, question, and improve the system—not to confirm predetermined product or
+> health claims.
+
+## Evidence to preserve
+
+Keep a dated, permission-aware record of the project brief, software version,
+student deliverables, sponsor feedback, defects, corrections, adoption
+decisions, presentations, publications, and citations. Store educational and
+institutional evidence separately from participant data.
+
+An institutional project demonstrates external engagement only when the
+institution actually accepts and conducts it. Future adoption, impact,
+publication, or recognition must not be claimed before it occurs.
+
+## Connected resources
+
+- [System Architecture](../architecture/SYSTEM-ARCHITECTURE.md)
+- [Benchmark and Evaluation Framework](../evaluation/BENCHMARK-FRAMEWORK.md)
+- [Validation Plan](../VALIDATION-PLAN.md)
+- [AI Risk Register](../AI-RISK-REGISTER.md)
+- [Open Curriculum](../learning-cases/OPEN-CURRICULUM.md)
+- [Evidence Map](../learning-cases/EVIDENCE-MAP.md)

--- a/aoi_kinabot_app/docs/evaluation/BENCHMARK-FRAMEWORK.md
+++ b/aoi_kinabot_app/docs/evaluation/BENCHMARK-FRAMEWORK.md
@@ -1,0 +1,70 @@
+# KinaBot Benchmark and Evaluation Framework
+
+**Status:** Public evaluation specification; not a report of completed results
+**Purpose:** Make technical and human-centered evaluation reproducible
+
+KinaBot should not be benchmarked by one accuracy number. A longitudinal,
+multilingual system must be evaluated across transcription, feature
+reproducibility, reliability, robustness, human understanding, privacy, and
+operations.
+
+## Benchmark layers
+
+| Layer | Question | Candidate measures |
+|---|---|---|
+| Transcription | Does speech-to-text perform consistently across languages and conditions? | WER/CER, failure rate, latency, language-stratified error |
+| Feature engine | Are derived features deterministic and versioned? | Same-input consistency, regression fixtures, provenance completeness |
+| Reliability | Are measurements stable under comparable repeated conditions? | Test-retest estimates, within-person variance, minimum detectable change after study design |
+| Robustness | How do device, duration, noise, and task changes affect output? | Stratified error, sensitivity analysis, audio-quality eligibility |
+| Human experience | Do people understand the result and its limitations? | Completion, comprehension, misinterpretation, accessibility, deletion-task success |
+| Privacy and governance | Does implementation match the stated data lifecycle? | Audio deletion, transcript non-retention, authorization, pseudonymization, deletion tests |
+| Operations | Can the service remain reliable and sustainable? | Availability, error rate, latency, cost per successful analysis, retry correctness |
+| Claims compliance | Does every surface preserve the non-diagnostic boundary? | Structured content review and prohibited-claim tests |
+
+## Minimum benchmark protocol
+
+Every evaluation should publish or retain:
+
+1. research question and intended use;
+2. software, scoring, transcription, and adapter versions;
+3. language, device, task, recording condition, and inclusion criteria;
+4. dataset source, consent, governance, and representativeness limits;
+5. metrics selected before viewing favorable results;
+6. uncertainty, missingness, exclusions, and negative findings;
+7. reproducible test code or a documented reason it cannot be shared;
+8. allowed conclusion and prohibited conclusion;
+9. independent reviewer or replication status.
+
+## Comparison rules
+
+Compare KinaBot with a category or named system only when task, population,
+language, input quality, intended use, and metric are aligned. Do not claim
+superiority from feature lists or marketing.
+
+| Category | Appropriate comparison question |
+|---|---|
+| Voice journal | Does it support user-controlled recording and meaningful longitudinal review? |
+| Consumer wellness product | Are trends, privacy controls, and claims understandable? |
+| Research speech pipeline | Are methods, versions, handling, and outputs reproducible? |
+| Clinically validated assessment | What external validation and intended use exist that KinaBot does not yet have? |
+
+The current system supports descriptive longitudinal reflection. Clinical
+validity remains an evidence gap, not a benchmark score to infer.
+
+## Student benchmark projects
+
+- **Multilingual reliability:** stratify transcription and feature stability by
+  language without assuming cross-language score equivalence.
+- **Recording robustness:** test duration, device, distance, and controlled
+  noise using consented or synthetic fixtures.
+- **Dignity-first comprehension:** test whether users understand observable
+  variation and do not infer diagnosis.
+- **Private API verification:** test authorization, HMAC pseudonyms, retention,
+  deletion, provenance, and localhost-only exposure.
+- **Responsible usage policy:** verify that failures do not consume quota and
+  study settings do not silently change public policy.
+
+Never publish participant audio, transcripts, raw identifiers, secrets, or
+small-cell results that create re-identification risk. Engineering tests do not
+establish health benefit, clinical validity, legal compliance, or regulatory
+authorization.

--- a/aoi_kinabot_app/docs/learning-cases/OPEN-CURRICULUM.md
+++ b/aoi_kinabot_app/docs/learning-cases/OPEN-CURRICULUM.md
@@ -90,6 +90,36 @@ network, storage, pseudonymisation, and acceptance-test design.
 **Practice:** threat-model short participant IDs and design a reproducible
 offline handoff without disabling security checks.
 
+## Module 8 · Responsible Interpretation
+
+**Case:** [From Feature Variation to Responsible Interpretation](aoi-maintained-product/2026-08-12-feature-variation-responsible-interpretation.md)
+
+**Learn:** separate recorded observation, descriptive pattern, and validated
+interpretation; identify confounders before assigning meaning to change.
+
+**Practice:** specify one permitted conclusion, one prohibited conclusion, and
+the external evidence required for a stronger claim.
+
+## Module 9 · Responsible Product Limits
+
+**Case:** [When a Product Limit Protects the User](aoi-maintained-product/2026-08-12-responsible-usage-limits.md)
+
+**Learn:** balance agency, repetitive behavior, reliability, research context,
+cost, and sustainability without making technical failure the user's burden.
+
+**Practice:** design a context-specific quota policy and tests for retries,
+partial failures, concurrency, and local-time reset.
+
+## Module 10 · Benchmark Before Claim
+
+**Reference:** [Benchmark and Evaluation Framework](../evaluation/BENCHMARK-FRAMEWORK.md)
+
+**Learn:** evaluate a multilingual longitudinal system across reliability,
+robustness, comprehension, privacy, operations, and claims compliance.
+
+**Practice:** write a reproducible benchmark protocol that publishes negative
+findings and preserves participant privacy.
+
 ## Capstone · An Evidence-Bounded Product Change
 
 Learners select one real product problem and submit:


### PR DESCRIPTION
﻿## What changed

- adds a public, reviewable KinaBot system architecture with online and Offline/Private Research trust boundaries
- adds a multidimensional benchmark framework covering transcription, reproducibility, reliability, robustness, comprehension, privacy, operations, and claims compliance
- adds an institution-neutral startup-sponsored student project framework with student independence, attribution, IP, privacy, and ethics safeguards
- expands the Open Curriculum from seven to ten modules by adding responsible interpretation, responsible product limits, and benchmark-before-claim
- links all resources from the Open Knowledge Center

## Why

KinaBot's real engineering and product decisions can serve as reusable public education only when architecture, evaluation standards, and student-project boundaries are explicit. These documents make the system easier to inspect and teach without exposing participant data or presenting planned validation and adoption as completed achievements.

## Public and educational value

The resources support university data science, HCI, responsible AI, digital health, software architecture, product management, and entrepreneurship education. They invite independent testing and negative findings rather than requiring students to confirm sponsor claims.

## Evidence boundary

- the benchmark is a specification, not a report of completed results
- no school, student, participant, or confidential partner is named
- no user records, credentials, recordings, transcripts, or private exports are included
- engineering behavior is not represented as clinical validity or health benefit
- external adoption and impact must be documented only after they occur

## Checks

- all local Markdown links resolve
- privacy and secret-pattern review completed
- `git diff --cached --check` passed after formatting cleanup
- commit is attributed to Aoi Minamoto
