### PR TITLE
Clarify and harden offline bundle delivery

### DIFF
--- a/aoi_kinabot_app/OFFLINE-QUICKSTART.md
+++ b/aoi_kinabot_app/OFFLINE-QUICKSTART.md
@@ -1,5 +1,11 @@
 # KinaBot Offline Research — Quick Start
 
+> The public GitHub repository does not include `wheelhouse/` or
+> `models/whisper-small/`. These large, versioned third-party artifacts belong
+> to a separately built and checksum-verified institutional delivery bundle.
+> If you received only a GitHub link, request the complete offline bundle from
+> the KinaBot maintainer before starting installation.
+
 ## For the Study Administrator
 
 1. Copy the complete approved KinaBot offline bundle to the encrypted research

--- a/aoi_kinabot_app/build-offline-bundle.ps1
+++ b/aoi_kinabot_app/build-offline-bundle.ps1
@@ -10,7 +10,7 @@ $ErrorActionPreference = "Stop"
 $wheelhouse = Resolve-Path -LiteralPath $WheelhousePath -ErrorAction Stop
 $model = Resolve-Path -LiteralPath $WhisperModelPath -ErrorAction Stop
 $repoRoot = Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..")
-$commit = (& git -C $repoRoot.Path rev-parse --short=12 HEAD).Trim()
+$commit = (& git -c "safe.directory=$($repoRoot.Path)" -C $repoRoot.Path rev-parse --short=12 HEAD).Trim()
 if (-not $commit) { throw "Unable to determine the Git commit." }
 
 $output = New-Item -ItemType Directory -Force -Path $OutputDirectory
@@ -20,7 +20,7 @@ if (Test-Path -LiteralPath $stage) {
     throw "Bundle staging directory already exists: $stage"
 }
 
-& git -C $repoRoot.Path archive --format=zip --output=$archive HEAD aoi_kinabot_app
+& git -c "safe.directory=$($repoRoot.Path)" -C $repoRoot.Path archive --format=zip --output=$archive HEAD aoi_kinabot_app
 Expand-Archive -LiteralPath $archive -DestinationPath $output.FullName
 Move-Item -LiteralPath (Join-Path $output.FullName "aoi_kinabot_app") -Destination $stage
 Remove-Item -LiteralPath $archive


### PR DESCRIPTION
﻿## What changed

- Clarifies that the public repository does not contain the large `wheelhouse/` or `models/whisper-small/` artifacts and that researchers need the complete verified institutional bundle.
- Makes the bundle builder robust when Git runs under a managed Windows account with a different repository owner.

## Why

A university research intern followed the public offline instructions but reasonably could not find the required model and wheelhouse. The documentation now distinguishes public source from the separately delivered, checksum-verified bundle.

## Validation

A Windows 11 / Python 3.11 pilot bundle was built from commit `3e37e65f4984` and validated separately:

- 178/178 manifest entries verified
- clean installation using only the bundled wheelhouse
- bundled faster-whisper-small model loaded locally on CPU/int8
- 27/27 multilingual, offline-mode, and local API tests passed

The generated model, wheelhouse, test environment, and 615 MB ZIP are intentionally excluded from GitHub.
