### PR TITLE
Fix English connector boundary scoring

### DIFF
--- a/aoi_kinabot_app/SCORING-METHODOLOGY.md
+++ b/aoi_kinabot_app/SCORING-METHODOLOGY.md
@@ -1,6 +1,6 @@
 # KinaBot V1.1 Scoring Methodology
 
-Scoring model version: `score-v2-multilingual`
+Scoring model version: `score-v3-connector-boundaries`
 
 ## Purpose
 
@@ -65,6 +65,13 @@ representative recordings before broad interpretation.
 | Emotional Tone | Counts from a small language-specific expression lexicon |
 | Transcription Clarity | Amount of recognizable transcript evidence |
 
+English discourse connectors are counted only when their normalized tokens
+match complete connector token sequences. Substrings inside unrelated words do
+not count; for example, `and` in `candy` and `if` in `gift` are excluded. Each
+real occurrence is counted, including repeated connectors. Japanese and Chinese
+use their language-specific connector matching behavior rather than English
+word-boundary rules.
+
 ## Longitudinal Display
 
 - Sessions 1–2: display the current sample only.
@@ -89,6 +96,10 @@ Any future change to tokenization, reference centers, feature formulas, or
 feature definitions must increment the scoring-model version. Scores from
 different versions should not be placed on one uninterrupted trend line
 without a documented migration or recalculation method.
+
+The application therefore limits displayed trend calculations to sessions from
+the current scoring-model version. Older sessions remain available in research
+exports with their original version metadata.
 
 ## Validation Status
 

--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -752,7 +752,9 @@ primary_view = st.radio(
 
 if primary_view == "trends":
     assign_timezone_to_legacy_sessions(st.session_state.user_id, browser_timezone)
-    rows = get_user_scores(st.session_state.user_id)
+    rows = get_user_scores(
+        st.session_state.user_id, scoring_model_version=SCORING_MODEL_VERSION
+    )
     st.subheader(history_copy["trends"])
     if not rows:
         st.caption(history_copy["no_scores"])

--- a/aoi_kinabot_app/config.py
+++ b/aoi_kinabot_app/config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 APP_VERSION = "v1.2-offline-research"
 CONSENT_VERSION = "consent-v1.1"
-SCORING_MODEL_VERSION = "score-v2-multilingual"
+SCORING_MODEL_VERSION = "score-v3-connector-boundaries"
 OPENAI_INSIGHT_MODEL = os.getenv("KINABOT_INSIGHT_MODEL", "gpt-5.6-luna")
 ENVIRONMENT = os.getenv("KINABOT_ENVIRONMENT", "development").strip().lower()
 OFFLINE_RESEARCH_MODE = (

--- a/aoi_kinabot_app/database.py
+++ b/aoi_kinabot_app/database.py
@@ -386,10 +386,16 @@ def save_feature_scores(test_session_id: int, scores: Iterable[dict]) -> None:
         )
 
 
-def get_user_scores(user_id: int) -> list[sqlite3.Row]:
+def get_user_scores(
+    user_id: int, scoring_model_version: str | None = None
+) -> list[sqlite3.Row]:
+    version_clause = " AND ts.scoring_model_version = ?" if scoring_model_version else ""
+    parameters: tuple = (
+        (user_id, scoring_model_version) if scoring_model_version else (user_id,)
+    )
     with get_connection() as conn:
         return conn.execute(
-            """
+            f"""
             SELECT
                 ts.id AS session_id,
                 ts.created_at,
@@ -405,10 +411,10 @@ def get_user_scores(user_id: int) -> list[sqlite3.Row]:
                 fs.score
             FROM feature_scores fs
             JOIN test_sessions ts ON ts.id = fs.test_session_id
-            WHERE ts.user_id = ?
+            WHERE ts.user_id = ?{version_clause}
             ORDER BY ts.created_at ASC, fs.feature_name ASC
             """,
-            (user_id,),
+            parameters,
         ).fetchall()
 
 

--- a/aoi_kinabot_app/docs/methodology/METRIC-DEFINITIONS.md
+++ b/aoi_kinabot_app/docs/methodology/METRIC-DEFINITIONS.md
@@ -1,6 +1,6 @@
 # How KinaBot Produces the Eight Feature Indexes
 
-Model version: `score-v2-multilingual`
+Model version: `score-v3-connector-boundaries`
 
 KinaBot uses its own Python and multilingual NLP pipeline. Audio is transcribed
 privately by the application, then language-specific tokenization and acoustic
@@ -21,6 +21,11 @@ cognitive test result.
 | Repetition Pattern | Repeated instances relative to total units | Lower repetition ratio maps to a higher display index |
 | Emotional Tone | Small language-specific positive/negative wording lexicon | Bounded balance of detected wording; topic strongly affects it |
 | Recording Clarity | Amount of recognizable transcript evidence | Tiered index based on usable recognized units |
+
+For English sentence structure, connectors are matched as complete normalized
+token sequences. Connector text embedded inside an unrelated word is not
+counted, while repeated standalone connectors are counted repeatedly. Japanese
+and Chinese retain language-specific matching rules.
 
 English uses regular-expression word tokens, Japanese uses Janome
 morphological analysis, and Chinese uses jieba segmentation. Pace and response

--- a/aoi_kinabot_app/scoring.py
+++ b/aoi_kinabot_app/scoring.py
@@ -177,13 +177,34 @@ def score_response_length(words: list[str], language: str) -> tuple[float, str]:
     return clamp_score((total / target) * 100), f"units={total}; target={target}"
 
 
+def count_english_connectors(words: list[str], connectors: set[str]) -> int:
+    """Count connector token sequences without matching inside other words."""
+    normalized_words = [word.lower() for word in words]
+    connector_count = 0
+    for connector in connectors:
+        connector_words = tokenize(connector, "English")
+        width = len(connector_words)
+        if not width:
+            continue
+        connector_count += sum(
+            normalized_words[index : index + width] == connector_words
+            for index in range(len(normalized_words) - width + 1)
+        )
+    return connector_count
+
+
 def score_sentence_complexity(
     text: str, words: list[str], sentences: list[str], language: str
 ) -> tuple[float, str]:
     sentence_count = len(sentences)
     avg_len = len(words) / sentence_count if sentence_count else 0.0
-    connectors = CONNECTORS[language_code(language)]
-    connector_count = sum(text.lower().count(connector) for connector in connectors)
+    code = language_code(language)
+    connectors = CONNECTORS[code]
+    if code == "en":
+        connector_count = count_english_connectors(words, connectors)
+    else:
+        # Japanese and Chinese connectors do not follow English word boundaries.
+        connector_count = sum(text.lower().count(connector) for connector in connectors)
     score = (min(avg_len, 20) / 20) * 70 + min(connector_count, 6) / 6 * 30
     return clamp_score(score), f"avg_sentence_length={avg_len:.2f}; connectors={connector_count}"
 

--- a/aoi_kinabot_app/test_scoring_version_history.py
+++ b/aoi_kinabot_app/test_scoring_version_history.py
@@ -1,0 +1,40 @@
+import database
+
+
+def _save_session(user_id: int, version: str, score: float) -> None:
+    session_id = database.create_test_session(
+        user_id=user_id,
+        session_date="2026-08-24",
+        session_number=1,
+        app_version="test",
+        consent_version="test",
+        scoring_model_version=version,
+    )
+    database.save_feature_scores(
+        session_id,
+        [
+            {
+                "feature_name": "Sentence Complexity",
+                "raw_metric": "test",
+                "score": score,
+                "explanation": "test",
+            }
+        ],
+    )
+
+
+def test_score_history_can_be_limited_to_one_model_version(tmp_path, monkeypatch):
+    monkeypatch.setattr(database, "DATABASE_PATH", tmp_path / "kina.sqlite3")
+    database.init_db()
+    user_id = database.upsert_user("version-test")
+    _save_session(user_id, "score-v2-multilingual", 24.0)
+    _save_session(user_id, "score-v3-connector-boundaries", 14.0)
+
+    current_rows = database.get_user_scores(
+        user_id, scoring_model_version="score-v3-connector-boundaries"
+    )
+
+    assert len(current_rows) == 1
+    assert current_rows[0]["score"] == 14.0
+    assert current_rows[0]["scoring_model_version"] == "score-v3-connector-boundaries"
+    assert len(database.get_user_scores(user_id)) == 2

--- a/aoi_kinabot_app/test_sentence_complexity.py
+++ b/aoi_kinabot_app/test_sentence_complexity.py
@@ -1,0 +1,41 @@
+from scoring import (
+    count_english_connectors,
+    score_sentence_complexity,
+    split_sentences,
+    tokenize,
+)
+
+
+def sentence_score(text: str) -> tuple[float, str]:
+    words = tokenize(text, "English")
+    return score_sentence_complexity(
+        text, words, split_sentences(text), "English"
+    )
+
+
+def test_english_connector_substrings_do_not_increase_complexity():
+    score, raw_metric = sentence_score("Candy is a gift.")
+
+    assert score == 14.0
+    assert raw_metric == "avg_sentence_length=4.00; connectors=0"
+
+    _, softly_metric = sentence_score("They moved softly.")
+    assert softly_metric.endswith("connectors=0")
+
+
+def test_real_english_connectors_ignore_case_and_punctuation():
+    _, raw_metric = sentence_score("And, if it rains, stay because it is wet.")
+
+    assert raw_metric.endswith("connectors=3")
+
+
+def test_repeated_english_connectors_are_counted_repeatedly():
+    _, raw_metric = sentence_score("If it rains and if it snows, wait.")
+
+    assert raw_metric.endswith("connectors=3")
+
+
+def test_multiword_connectors_are_counted_as_token_sequences():
+    words = tokenize("Even though we left, even thoughts remained.", "English")
+
+    assert count_english_connectors(words, {"even though"}) == 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ pytest>=7.4.0
 hypothesis>=6.92.0
 reportlab>=4.0.0
 flake8>=7.3.0
+fastapi>=0.115.0
+python-multipart>=0.0.20
+httpx>=0.28.0


### PR DESCRIPTION
## Summary

- count English discourse connectors as complete normalized token sequences instead of raw substrings
- preserve repeated connector counts and support future multi-word connectors
- keep Japanese and Chinese connector behavior language-specific
- increment the scoring model version and prevent the trend UI from mixing model versions
- document the corrected metric definition and version behavior

## Validation

- `Candy is a gift.` now reports `connectors=0` and `score=14.0`
- capitalization, punctuation, repeated connectors, and multi-word token sequences have regression coverage
- version-filtered history has regression coverage
- 29 Aoi-maintained application tests pass

The repository-wide legacy test suite could not be collected in the local environment because optional dependencies (`fastapi`, `speech_recognition`, and `hypothesis`) are not installed. The complete `aoi_kinabot_app` suite, excluding only the FastAPI test that requires the missing `fastapi` package, passes.

Closes #39
