### PR TITLE
Separate edge silence from Pause Pattern scoring

### DIFF
--- a/aoi_kinabot_app/CHANGELOG.md
+++ b/aoi_kinabot_app/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-08-24 · Pause measurement boundary correction
+
+- Changed Pause Pattern to measure only gaps inside the detected speech span,
+  so leading or trailing recording silence no longer changes the index.
+- Preserved leading and trailing silence as separate raw recording metrics.
+- Added deterministic handling for invalid, overlapping, out-of-order, and
+  out-of-range segment timestamps.
+- Incremented the scoring model to `score-v4-internal-pause-span` and kept
+  cross-version scores off the same uninterrupted trend line.
+- Added regression coverage for edge padding, genuine internal-gap changes,
+  single-segment recordings, segment merging, and invalid timestamp inputs.
+
 ## 2026-08-10 · Offline/private research API
 
 - Added a dedicated localhost-only FastAPI subsystem so approved university

--- a/aoi_kinabot_app/SCORING-METHODOLOGY.md
+++ b/aoi_kinabot_app/SCORING-METHODOLOGY.md
@@ -1,6 +1,6 @@
 # KinaBot V1.1 Scoring Methodology
 
-Scoring model version: `score-v3-connector-boundaries`
+Scoring model version: `score-v4-internal-pause-span`
 
 ## Purpose
 
@@ -60,7 +60,7 @@ representative recordings before broad interpretation.
 | Response Length | Total language units relative to the language adapter |
 | Sentence Complexity | Units per sentence and discourse connectors |
 | Speech Pace | Language units per minute |
-| Pause Pattern | Voiced time, pause time/count, mean/maximum pause, pause ratio |
+| Pause Pattern | Voiced time, internal pause time/count, mean/maximum pause, internal pause ratio |
 | Repetition Pattern | Repeated units relative to total units |
 | Emotional Tone | Counts from a small language-specific expression lexicon |
 | Transcription Clarity | Amount of recognizable transcript evidence |
@@ -71,6 +71,13 @@ not count; for example, `and` in `candy` and `if` in `gift` are excluded. Each
 real occurrence is counted, including repeated connectors. Japanese and Chinese
 use their language-specific connector matching behavior rather than English
 word-boundary rules.
+
+Pause Pattern measures gaps between detected speech segments within the detected
+speech span. The internal pause ratio is total positive gap time divided by the
+interval from the first valid speech start to the last valid speech end. Leading
+and trailing recording silence are retained as separate raw metrics but do not
+affect the Pause Pattern score. Overlapping segments are merged before voiced
+and pause durations are calculated.
 
 ## Longitudinal Display
 
@@ -116,3 +123,7 @@ Future validation should include:
 - test-retest reliability;
 - subgroup fairness review; and
 - documented calibration changes.
+
+Whisper segment timestamps cannot detect every pause that occurs inside one
+segment. More precise word timestamps, audio-level voice activity detection,
+and real-recording calibration remain future validation work.

--- a/aoi_kinabot_app/config.py
+++ b/aoi_kinabot_app/config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 APP_VERSION = "v1.2-offline-research"
 CONSENT_VERSION = "consent-v1.1"
-SCORING_MODEL_VERSION = "score-v3-connector-boundaries"
+SCORING_MODEL_VERSION = "score-v4-internal-pause-span"
 OPENAI_INSIGHT_MODEL = os.getenv("KINABOT_INSIGHT_MODEL", "gpt-5.6-luna")
 ENVIRONMENT = os.getenv("KINABOT_ENVIRONMENT", "development").strip().lower()
 OFFLINE_RESEARCH_MODE = (

--- a/aoi_kinabot_app/docs/methodology/METRIC-DEFINITIONS.md
+++ b/aoi_kinabot_app/docs/methodology/METRIC-DEFINITIONS.md
@@ -1,6 +1,6 @@
 # How KinaBot Produces the Eight Feature Indexes
 
-Model version: `score-v3-connector-boundaries`
+Model version: `score-v4-internal-pause-span`
 
 KinaBot uses its own Python and multilingual NLP pipeline. Audio is transcribed
 privately by the application, then language-specific tokenization and acoustic
@@ -17,7 +17,7 @@ cognitive test result.
 | Response Length | Total recognized language units | Units relative to a language-specific pilot reference center |
 | Sentence Structure | Average units per sentence and connector count | Weighted, bounded combination of length and connectors |
 | Speech Pace | Language units and recording duration | Distance from a broad language-specific pilot center |
-| Pause Pattern | Pause ratio, count, mean, maximum, voiced and pause time | Weighted distance from broad descriptive centers |
+| Pause Pattern | Internal pause ratio, count, mean, maximum, voiced time, and edge silence | Weighted distance from broad descriptive centers; edge silence is excluded from the score |
 | Repetition Pattern | Repeated instances relative to total units | Lower repetition ratio maps to a higher display index |
 | Emotional Tone | Small language-specific positive/negative wording lexicon | Bounded balance of detected wording; topic strongly affects it |
 | Recording Clarity | Amount of recognizable transcript evidence | Tiered index based on usable recognized units |
@@ -26,6 +26,12 @@ For English sentence structure, connectors are matched as complete normalized
 token sequences. Connector text embedded inside an unrelated word is not
 counted, while repeated standalone connectors are counted repeatedly. Japanese
 and Chinese retain language-specific matching rules.
+
+The internal pause ratio divides positive gaps between valid detected speech
+segments by the span from the first speech start to the last speech end.
+Leading and trailing silence are reported separately and do not change the
+Pause Pattern index. Segment timestamps do not reveal every pause within a
+single Whisper segment, so this remains a descriptive engineering measure.
 
 English uses regular-expression word tokens, Japanese uses Janome
 morphological analysis, and Chinese uses jieba segmentation. Pace and response

--- a/aoi_kinabot_app/feature-score-design.md
+++ b/aoi_kinabot_app/feature-score-design.md
@@ -82,11 +82,12 @@ This reflects speaking pace in this sample. Faster or slower is not automaticall
 
 Measures pause and silence behavior in the audio sample.
 
-Possible raw metrics:
+Raw metrics:
 
-- Silence ratio
-- Average pause length
-- Number of long pauses
+- Internal pause ratio within the detected speech span
+- Internal pause count, mean, and maximum duration
+- Voiced duration and detected speech-span duration
+- Leading and trailing recording silence, reported separately and excluded from the score
 
 User-facing explanation:
 

--- a/aoi_kinabot_app/scoring.py
+++ b/aoi_kinabot_app/scoring.py
@@ -236,6 +236,10 @@ def score_pause_pattern(acoustic_metrics: dict | None) -> tuple[float, str]:
         in {
             "voiced_seconds",
             "pause_seconds",
+            "internal_pause_seconds",
+            "speech_span_seconds",
+            "leading_silence_seconds",
+            "trailing_silence_seconds",
             "pause_count",
             "mean_pause_seconds",
             "max_pause_seconds",

--- a/aoi_kinabot_app/speech_to_text.py
+++ b/aoi_kinabot_app/speech_to_text.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 import tempfile
 from functools import lru_cache
@@ -86,28 +87,53 @@ def transcribe_audio_upload(
 
 def calculate_pause_metrics(segments: list, duration_seconds: float | None) -> dict:
     """Calculate descriptive pause metrics from timestamped speech segments."""
-    ordered = sorted(
-        (
-            (max(0.0, float(segment.start)), max(0.0, float(segment.end)))
-            for segment in segments
-            if float(segment.end) > float(segment.start)
-        ),
-        key=lambda item: item[0],
-    )
-    if not ordered:
+    total_duration = max(0.0, float(duration_seconds or 0.0))
+    intervals = []
+    for segment in segments:
+        try:
+            start = max(0.0, float(segment.start))
+            end = max(0.0, float(segment.end))
+        except (AttributeError, TypeError, ValueError):
+            continue
+        if not math.isfinite(start) or not math.isfinite(end):
+            continue
+        if total_duration > 0:
+            start = min(start, total_duration)
+            end = min(end, total_duration)
+        if end > start:
+            intervals.append((start, end))
+
+    if not intervals:
         return {}
 
-    voiced_seconds = sum(end - start for start, end in ordered)
+    ordered = sorted(intervals, key=lambda item: item[0])
+    merged = []
+    for start, end in ordered:
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+
+    voiced_seconds = sum(end - start for start, end in merged)
     pauses = [
-        max(0.0, ordered[index][0] - ordered[index - 1][1])
-        for index in range(1, len(ordered))
+        merged[index][0] - merged[index - 1][1]
+        for index in range(1, len(merged))
     ]
     meaningful_pauses = [pause for pause in pauses if pause >= 0.25]
-    total_duration = duration_seconds or ordered[-1][1]
-    pause_seconds = max(0.0, total_duration - voiced_seconds)
+    first_speech_start = merged[0][0]
+    last_speech_end = merged[-1][1]
+    speech_span_seconds = last_speech_end - first_speech_start
+    internal_pause_seconds = sum(pauses)
+    effective_duration = total_duration or last_speech_end
+    leading_silence_seconds = first_speech_start
+    trailing_silence_seconds = max(0.0, effective_duration - last_speech_end)
     return {
         "voiced_seconds": round(voiced_seconds, 3),
-        "pause_seconds": round(pause_seconds, 3),
+        "pause_seconds": round(internal_pause_seconds, 3),
+        "internal_pause_seconds": round(internal_pause_seconds, 3),
+        "speech_span_seconds": round(speech_span_seconds, 3),
+        "leading_silence_seconds": round(leading_silence_seconds, 3),
+        "trailing_silence_seconds": round(trailing_silence_seconds, 3),
         "pause_count": len(meaningful_pauses),
         "mean_pause_seconds": round(
             sum(meaningful_pauses) / len(meaningful_pauses), 3
@@ -117,7 +143,7 @@ def calculate_pause_metrics(segments: list, duration_seconds: float | None) -> d
         "max_pause_seconds": round(max(meaningful_pauses), 3)
         if meaningful_pauses
         else 0.0,
-        "pause_ratio": round(pause_seconds / total_duration, 4)
-        if total_duration > 0
+        "pause_ratio": round(internal_pause_seconds / speech_span_seconds, 4)
+        if speech_span_seconds > 0
         else 0.0,
     }

--- a/aoi_kinabot_app/test_multilingual.py
+++ b/aoi_kinabot_app/test_multilingual.py
@@ -137,7 +137,11 @@ def test_pause_metrics_and_score_use_timestamps():
     )
     assert metrics["pause_count"] == 2
     assert metrics["max_pause_seconds"] == 1.5
-    assert metrics["pause_ratio"] == 0.45
+    assert metrics["internal_pause_seconds"] == 2.5
+    assert metrics["speech_span_seconds"] == 8.0
+    assert metrics["leading_silence_seconds"] == 0.0
+    assert metrics["trailing_silence_seconds"] == 2.0
+    assert metrics["pause_ratio"] == 0.3125
     scores = calculate_feature_scores(
         "Today I spoke clearly about my day.",
         10.0,

--- a/aoi_kinabot_app/test_pause_edge_silence.py
+++ b/aoi_kinabot_app/test_pause_edge_silence.py
@@ -1,0 +1,89 @@
+from scoring import score_pause_pattern
+from speech_to_text import calculate_pause_metrics
+
+
+class Segment:
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+
+
+def test_edge_padding_does_not_change_internal_pause_score():
+    cropped = calculate_pause_metrics(
+        [Segment(0.0, 2.0), Segment(3.0, 5.0)], 5.0
+    )
+    padded = calculate_pause_metrics(
+        [Segment(2.0, 4.0), Segment(5.0, 7.0)], 10.0
+    )
+
+    for key in (
+        "internal_pause_seconds",
+        "speech_span_seconds",
+        "pause_count",
+        "mean_pause_seconds",
+        "max_pause_seconds",
+        "pause_ratio",
+    ):
+        assert padded[key] == cropped[key]
+    assert score_pause_pattern(padded)[0] == score_pause_pattern(cropped)[0]
+    assert padded["leading_silence_seconds"] == 2.0
+    assert padded["trailing_silence_seconds"] == 3.0
+
+
+def test_a_real_internal_gap_changes_pause_metrics_and_score():
+    short_gap = calculate_pause_metrics(
+        [Segment(0.0, 2.0), Segment(3.0, 5.0)], 5.0
+    )
+    long_gap = calculate_pause_metrics(
+        [Segment(0.0, 2.0), Segment(4.0, 6.0)], 6.0
+    )
+
+    assert short_gap["internal_pause_seconds"] == 1.0
+    assert long_gap["internal_pause_seconds"] == 2.0
+    assert short_gap["pause_ratio"] == 0.2
+    assert long_gap["pause_ratio"] == 0.3333
+    assert score_pause_pattern(short_gap)[0] != score_pause_pattern(long_gap)[0]
+
+
+def test_single_segment_reports_edge_silence_without_internal_pause():
+    metrics = calculate_pause_metrics([Segment(2.0, 5.0)], 8.0)
+
+    assert metrics["voiced_seconds"] == 3.0
+    assert metrics["internal_pause_seconds"] == 0
+    assert metrics["pause_ratio"] == 0.0
+    assert metrics["leading_silence_seconds"] == 2.0
+    assert metrics["trailing_silence_seconds"] == 3.0
+
+
+def test_overlapping_out_of_order_segments_are_merged():
+    metrics = calculate_pause_metrics(
+        [Segment(4.0, 6.0), Segment(1.0, 3.0), Segment(2.0, 5.0)], 8.0
+    )
+
+    assert metrics["voiced_seconds"] == 5.0
+    assert metrics["speech_span_seconds"] == 5.0
+    assert metrics["internal_pause_seconds"] == 0
+    assert metrics["pause_count"] == 0
+
+
+def test_invalid_and_out_of_range_segments_are_handled_deterministically():
+    metrics = calculate_pause_metrics(
+        [
+            Segment("invalid", 2.0),
+            Segment(float("inf"), float("inf")),
+            Segment(-2.0, 1.0),
+            Segment(9.0, 12.0),
+            Segment(4.0, 4.0),
+        ],
+        10.0,
+    )
+
+    assert metrics["voiced_seconds"] == 2.0
+    assert metrics["internal_pause_seconds"] == 8.0
+    assert metrics["speech_span_seconds"] == 10.0
+    assert metrics["pause_ratio"] == 0.8
+
+
+def test_no_valid_segments_returns_no_pause_analysis():
+    assert calculate_pause_metrics([], 10.0) == {}
+    assert calculate_pause_metrics([Segment(2.0, 2.0)], 10.0) == {}


### PR DESCRIPTION
## Summary

- calculate Pause Pattern from gaps inside the detected speech span
- keep leading and trailing recording silence as separate raw metrics
- merge overlapping segments and handle invalid or out-of-range timestamps deterministically
- increment the scoring model to `score-v4-internal-pause-span`
- document the corrected definition, version boundary, and Whisper timestamp limitation

## AWS-hosted app alignment

All product code and documentation changes are under `aoi_kinabot_app/`, which is the Docker build context used by `aoi_kinabot_app/aws/deploy.ps1` for the ECS Fargate application.

## Validation

- edge padding leaves internal pause metrics and Pause Pattern score unchanged
- genuine internal-gap changes still change the metric and score
- single, overlapping, out-of-order, invalid, and out-of-range segments have regression coverage
- 35 Aoi-maintained application tests pass locally

Addresses #38
