### PR TITLE
Improve contributor onboarding and review standards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,61 +1,230 @@
 # Contributing to KinaBot
 
-Thank you for your interest in contributing to KinaBot.
+Thank you for helping make KinaBot safer, clearer, more accessible, and more
+reliable. Contributions are welcome in many forms: code, tests, documentation,
+translations, accessibility review, privacy review, reproducible research,
+issue triage, and product feedback.
 
-KinaBot is maintained as a dignity-first, consent-first, privacy-aware project for speech and language-based cognitive wellness reflection.
+KinaBot is a dignity-first, consent-first, privacy-aware project for speech and
+language-based cognitive wellness reflection. Please read the responsible-use
+boundaries below before proposing or implementing a change.
 
-## Current Development Area
+## Start Here
 
-Current Aoi-maintained development is located in `aoi_kinabot_app/`.
+Active development is in [`aoi_kinabot_app/`](aoi_kinabot_app/). Files outside
+that directory may be historical exploratory material unless the repository
+documentation says otherwise.
 
-Please treat files outside `aoi_kinabot_app/` as historical exploratory materials unless otherwise stated.
+Before starting substantial work:
 
-## Responsible Contribution Guidelines
+1. Search existing [issues](https://github.com/usekina/kina/issues) and pull
+   requests to avoid duplicating work.
+2. Open or comment on an issue describing the problem, intended users, proposed
+   outcome, risks, and measurable acceptance criteria.
+3. Wait for maintainer alignment before investing in a large feature or changing
+   scoring, data handling, consent, safety wording, dependencies, or architecture.
 
-Contributions should align with KinaBot's responsible-use boundaries.
+Small documentation corrections and narrowly scoped bug fixes may go directly
+to a pull request when the problem and solution are clear.
 
-Please do not add features or wording that present KinaBot as:
+## Choose the Right Contribution
 
-- A medical diagnostic tool
-- A dementia risk predictor
-- A disease prediction system
-- A cognitive age or biological age estimator
-- A treatment recommendation system
-- A replacement for licensed healthcare professionals
+### Report a bug
+
+Include:
+
+- a short description of the observed and expected behavior;
+- exact steps and the smallest safe example needed to reproduce it;
+- browser, operating system, Python version, and relevant app mode;
+- logs or screenshots with secrets and personal data removed;
+- possible impact on scoring, privacy, consent, deletion, or accessibility.
+
+Never attach real participant audio, transcripts, email addresses, credentials,
+medical information, or other sensitive data to a public issue. Create synthetic
+test data that reproduces the behavior instead.
+
+### Propose a feature or improvement
+
+Explain:
+
+- the user and problem, not only the requested interface or technology;
+- evidence that the problem exists and why the current workflow is insufficient;
+- the smallest useful scope and explicit non-goals;
+- acceptance criteria that another person can verify;
+- privacy, safety, accessibility, multilingual, migration, and maintenance
+  implications.
+
+Broad ideas such as “build a mobile app” must be refined into an actionable user
+journey and testable outcome before implementation.
+
+### Report a security or privacy concern
+
+Do not publish exploit details, credentials, personal data, or an unpatched
+vulnerability in a public issue. Use GitHub's private vulnerability reporting
+for this repository when available. If no private channel is visible, contact
+the maintainer privately and disclose only the minimum information necessary
+until a safe reporting path is agreed.
+
+## Responsible-Use Boundaries
+
+Do not add features, labels, marketing claims, or documentation that present
+KinaBot as:
+
+- a medical diagnostic tool;
+- a dementia or disease-risk predictor;
+- a cognitive-age or biological-age estimator;
+- a treatment recommendation system;
+- evidence of clinical improvement or decline; or
+- a replacement for licensed healthcare professionals.
+
+Feature indexes are descriptive engineering measures of a speech sample. A
+change to scoring must document its definition, limitations, language rules,
+tests, and versioning or migration impact. Historical trends must not silently
+mix incompatible scoring versions.
 
 Preferred contributions include:
 
-- Privacy-aware data handling
-- Accessibility improvements
-- Clear documentation
-- Safer user interface wording
-- Feature-level speech and language scoring
-- Trend visualization
-- Testing and reliability improvements
-- Multilingual support with clear limitations
+- privacy-aware collection, retention, export, and deletion controls;
+- accessibility and mobile-web improvements;
+- clear, non-clinical interface wording and documentation;
+- reliable, explainable feature-level scoring;
+- honest trend visualization;
+- tests, observability, and failure recovery;
+- multilingual support with language-specific rules and stated limitations.
 
-## Contribution Rights
+## Local Development
 
-By contributing to this repository, you confirm that:
+KinaBot currently targets Python 3.10 in continuous integration.
 
-- You have the right to submit your contribution.
-- Your contribution is your own work or is properly licensed for inclusion.
-- Your contribution may be used under this repository's license.
-- Your contribution does not include confidential, proprietary, medical, or personal data that you do not have permission to share.
+From the repository root on Windows PowerShell:
 
-## Pull Requests
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+```
 
-Before opening a pull request, please make sure your contribution:
+On macOS or Linux:
 
-- Is aligned with the current V1 direction
-- Does not add medical diagnosis-like claims
-- Does not store raw audio or transcripts by default
-- Deletes temporary audio files even when transcription or scoring fails
-- Does not add sensitive personal data collection without clear justification
-- Includes clear documentation when behavior changes
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+```
 
-The maintainer may reject or request changes to contributions that increase privacy, safety, ownership, or responsible-use risk.
+Run the maintained Streamlit application:
+
+```bash
+cd aoi_kinabot_app
+streamlit run app.py
+```
+
+Never commit `.env` files, cloud credentials, API keys, participant data,
+generated local databases, or production exports. Use synthetic data in tests
+and examples.
+
+## Make a Focused Change
+
+1. Fork the repository and create a branch from the latest `main`.
+2. Use a short descriptive branch name, such as `fix/connector-boundaries` or
+   `docs/contribution-guide`.
+3. Keep each pull request focused on one problem. Avoid unrelated formatting,
+   dependency, or generated-file changes.
+4. Add or update tests for behavior changes and update documentation for
+   user-visible or operational changes.
+5. Preserve safe cleanup behavior: temporary audio must be deleted even when
+   transcription, scoring, storage, or rendering fails.
+
+Commit messages should explain the outcome in imperative language, for example:
+
+```text
+Fix connector matching at English token boundaries
+Document scoring-version migration rules
+```
+
+## Test Before Opening a Pull Request
+
+Run the same core checks used by continuous integration from the repository
+root:
+
+```bash
+python -m pytest
+python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+```
+
+Also run focused tests while developing, for example:
+
+```bash
+python -m pytest aoi_kinabot_app/test_sentence_complexity.py
+```
+
+If a check cannot run in your environment, explain why in the pull request. Do
+not remove or weaken a test merely to make CI pass without documenting the
+underlying behavior change.
+
+## Pull Request Requirements
+
+In the pull request description:
+
+- link the related issue (`Fixes #123` only when merging should close it);
+- explain what changed, why it changed, and what is intentionally out of scope;
+- list automated checks and manual flows used for verification;
+- include before/after screenshots for visible changes, with private data
+  removed;
+- identify scoring-version, migration, privacy, security, accessibility,
+  multilingual, and AWS deployment impacts—or state that each is not applicable;
+- update user, scoring, API, operations, or deployment documentation as needed;
+- disclose each new dependency and explain why it is necessary.
+
+Before requesting review, confirm that the change:
+
+- does not add diagnosis-like claims or misleading certainty;
+- does not store raw audio or transcripts by default;
+- does not add sensitive-data collection without explicit purpose and consent;
+- preserves deletion, retention, and failure-cleanup behavior;
+- contains no secrets, personal data, or confidential material;
+- includes regression tests for fixed bugs and acceptance tests for new behavior;
+- keeps existing user workflows working unless the change is intentionally
+  breaking and includes a documented migration path.
+
+## Definition of Done
+
+A contribution is complete when its agreed acceptance criteria are met, relevant
+tests pass, documentation is current, safety and privacy effects are addressed,
+and a maintainer has reviewed and merged it. Merge does not by itself prove that
+a change has been deployed to AWS or validated with real users; deployment and
+measured outcomes must be recorded separately when they are part of the scope.
+
+Review is collaborative and may require revision. A maintainer may decline work
+that is out of scope or introduces unacceptable privacy, safety, ownership,
+maintenance, or responsible-use risk. Decisions should be explained in the
+relevant issue or pull request. Because maintainer capacity varies, the project
+does not promise a fixed response or merge time.
+
+## Contribution Rights and Recognition
+
+By contributing, you confirm that:
+
+- you have the right to submit the contribution;
+- it is your own work or is properly licensed for inclusion;
+- it may be distributed under this repository's license; and
+- it contains no confidential, proprietary, medical, or personal data that you
+  lack permission to share.
+
+We recognize non-code contributions as well as merged code. GitHub records issue
+authors, pull-request authors, reviewers, and commits; release notes or project
+documentation may also thank contributors for material work. Recognition does
+not imply that a contributor endorses every part of KinaBot.
+
+Please interact with empathy, respect different backgrounds and levels of
+experience, critique ideas rather than people, and protect participant dignity.
+Harassment, discrimination, doxxing, and disclosure of private information are
+not acceptable.
 
 ## Current Maintainership
 
-KinaBot is currently maintained by Aoi Minamoto through AImoji LLC.
+KinaBot is currently maintained by Aoi Minamoto through AImoji LLC. Maintainers
+make final decisions on scope, safety boundaries, releases, and deployment while
+aiming to explain those decisions in the relevant issue or pull request.


### PR DESCRIPTION
## Summary

- turn the contribution guide into an actionable onboarding path;
- document safe bug, feature, privacy, and security reporting;
- provide reproducible Windows, macOS, and Linux setup commands;
- define branch, commit, test, pull-request, and completion standards;
- add scoring-version, privacy, accessibility, multilingual, migration, and deployment review gates;
- recognize non-code contributions without implying project-wide endorsement.

## Why

The previous guide expressed KinaBot's responsible-use values but did not tell a new contributor how to set up the project, propose scoped work, verify a change, or prepare a reviewable pull request. This update reduces onboarding ambiguity while preserving the project's dignity-first and non-clinical boundaries.

## Validation

- `git diff --check`
- verified commands against the current Python 3.10 CI workflow and repository test layout
- documentation-only change; no runtime or AWS deployment impact

## Review considerations

- No medical or diagnostic claims introduced.
- No scoring behavior, data handling, dependencies, or production configuration changed.
- The guide intentionally avoids promising a fixed maintainer response time.
