### PR TITLE
Establish source-available community governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Current Aoi-maintained product. Repository settings should require Code Owner
+# review on the protected main branch for this rule to be enforced by GitHub.
+/aoi_kinabot_app/ @aoiminamoto
+
+# Community governance and legal-policy surfaces require maintainer review.
+/LICENSE.md @aoiminamoto
+/LICENSING.md @aoiminamoto
+/COMMERCIAL-LICENSING.md @aoiminamoto
+/CLA.md @aoiminamoto
+/TRADEMARKS.md @aoiminamoto
+/SECURITY.md @aoiminamoto
+/CODE_OF_CONDUCT.md @aoiminamoto
+/.github/ @aoiminamoto

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,87 @@
+name: Bug report
+description: Report a reproducible defect without exposing private or sensitive data.
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping improve KinaBot. Search existing issues first. Use only synthetic data and report security vulnerabilities through the private channel in SECURITY.md.
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety check
+      options:
+        - label: I searched existing issues and did not find the same report.
+          required: true
+        - label: This report contains no participant audio, transcript, personal data, credentials, secrets, or unpatched exploit details.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the observed behavior and its user impact.
+      placeholder: A concise description of the defect and who it affects.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest deterministic example using synthetic data.
+      placeholder: |
+        1. Start the app with ...
+        2. Select ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Participant web experience
+        - Scoring or trend history
+        - Transcription or audio cleanup
+        - Offline/private research API
+        - Research administration or export
+        - Authentication, consent, deletion, or retention
+        - Documentation or deployment
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: Release, commit SHA, branch, or deployment date if known.
+      placeholder: main at abc1234
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, browser, Python version, app mode, and relevant deployment details.
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Risk and impact
+      description: Note possible scoring, privacy, consent, deletion, accessibility, multilingual, or data-migration impact.
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Redacted evidence
+      description: Add sanitized logs or screenshots. Drag files here only after removing all sensitive information.
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Suggested acceptance criteria
+      description: What observable tests would prove the bug is fixed without regression?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security or privacy vulnerability
+    url: https://github.com/usekina/kina/security/policy
+    about: Report vulnerabilities privately; never place exploit or participant data in a public issue.
+  - name: Responsible-use and safety guidance
+    url: https://github.com/usekina/kina/blob/main/CONTRIBUTING.md#responsible-use-boundaries
+    about: Review KinaBot's non-clinical, dignity-first contribution boundaries.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,83 @@
+name: Feature or improvement
+description: Propose a scoped, testable improvement grounded in a user need.
+title: "[Proposal]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the user problem before the solution. A proposal is a starting point, not a delivery commitment.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues, pull requests, and the roadmap.
+          required: true
+        - label: This proposal respects KinaBot's non-clinical and consent-first boundaries.
+          required: true
+  - type: textarea
+    id: user_problem
+    attributes:
+      label: User and problem
+      description: Who experiences the problem, in what context, and what evidence supports it?
+    validations:
+      required: true
+  - type: textarea
+    id: current_gap
+    attributes:
+      label: Current workflow and gap
+      description: Explain why the current experience is insufficient.
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the smallest useful outcome without unnecessarily prescribing implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and non-goals
+      description: State what is included and explicitly excluded.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List measurable conditions another person can verify.
+      placeholder: |
+        - [ ] Given ..., when ..., then ...
+        - [ ] Regression coverage includes ...
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What simpler options or workarounds were considered?
+  - type: checkboxes
+    id: impacts
+    attributes:
+      label: Impact areas to evaluate
+      options:
+        - label: Privacy, consent, retention, or deletion
+        - label: Security or abuse resistance
+        - label: Accessibility or older-adult usability
+        - label: Scoring definition, versioning, or historical trends
+        - label: Multilingual behavior
+        - label: Data/API migration or backward compatibility
+        - label: AWS operations, cost, or deployment
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks, limitations, and maintenance
+      description: Describe likely failure modes, misuse, ongoing ownership, and dependencies.
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Supporting evidence
+      description: Link non-sensitive research, mockups, feedback, or examples; disclose assumptions.

--- a/.github/ISSUE_TEMPLATE/privacy_safety_review.yml
+++ b/.github/ISSUE_TEMPLATE/privacy_safety_review.yml
@@ -1,0 +1,59 @@
+name: Privacy or responsible-use review
+description: Raise a non-secret privacy, consent, accessibility, or product-safety concern.
+title: "[Privacy/Safety]: "
+labels: ["privacy", "safety", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this public form only when the report contains no personal data, credentials, or exploitable vulnerability. Report those privately through SECURITY.md.
+  - type: checkboxes
+    id: public_safe
+    attributes:
+      label: Public-report confirmation
+      options:
+        - label: This report is safe to discuss publicly and contains no sensitive data or unpatched exploit details.
+          required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Concern category
+      options:
+        - Consent or user control
+        - Data collection, retention, export, or deletion
+        - Misleading clinical or scoring language
+        - Accessibility, inclusion, or coercion risk
+        - Multilingual fairness or language boundaries
+        - Research or deployment governance
+        - Other responsible-use concern
+    validations:
+      required: true
+  - type: textarea
+    id: scenario
+    attributes:
+      label: Scenario and affected people
+      description: Describe the realistic context, affected users, and potential harm using synthetic examples.
+    validations:
+      required: true
+  - type: textarea
+    id: current_control
+    attributes:
+      label: Existing control and gap
+      description: What currently mitigates the concern, and why is it insufficient?
+  - type: textarea
+    id: recommendation
+    attributes:
+      label: Recommended outcome
+      description: Suggest a proportionate mitigation, documentation change, or research question.
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation evidence
+      description: How should the project verify that risk is reduced without overstating results?
+  - type: checkboxes
+    id: boundaries
+    attributes:
+      label: Responsible disclosure
+      options:
+        - label: I understand that clinical, legal, and regulatory claims require independent evidence and review.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,66 @@
+## Summary
+
+<!-- What changed, why, and for whom? Keep this outcome-focused. -->
+
+## Related issue
+
+<!-- Use "Fixes #123" only when merging this PR should close the entire issue. -->
+
+## Scope
+
+<!-- State what is included and intentionally out of scope. -->
+
+<!-- Changes under aoi_kinabot_app/ must be authored and committed by Aoi using an approved identity. External contributors should use an issue or patch proposal for that area. -->
+
+## Verification
+
+<!-- List exact automated commands and manual user journeys with results. -->
+
+- [ ] `python -m pytest`
+- [ ] `python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
+- [ ] Focused regression or acceptance tests added/updated
+- [ ] Relevant manual flow verified, or not applicable
+
+## Evidence
+
+<!-- Add before/after screenshots for UI work and sanitized logs where useful. Never include participant or production data. -->
+
+## Impact review
+
+For each item, describe the impact below or write **Not applicable**.
+
+- **Scoring definition/version and historical trends:**
+- **Privacy, consent, retention, deletion, or temporary files:**
+- **Security and abuse resistance:**
+- **Accessibility and mobile behavior:**
+- **Multilingual behavior:**
+- **API/data migration and backward compatibility:**
+- **AWS deployment, operations, observability, and cost:**
+- **New or changed dependencies:**
+
+## Documentation and release notes
+
+- [ ] User, scoring, API, operations, or deployment documentation updated
+- [ ] Changelog/release note added for a notable user-visible or operational change
+- [ ] No documentation change is needed (explain why)
+
+## Responsible-use checklist
+
+- [ ] No diagnosis, disease prediction, cognitive-age, treatment, or unsupported clinical claims are introduced.
+- [ ] No secrets, personal data, participant audio, transcripts, or confidential material are committed.
+- [ ] Commit author and committer metadata use a personal or explicitly authorized project email, not an unrelated employer domain.
+- [ ] Raw audio and temporary sensitive files are not stored by default and cleanup still occurs on failure.
+- [ ] New data collection has an explicit purpose, consent path, retention rule, and deletion path.
+- [ ] Synthetic data is used in tests, examples, screenshots, and logs.
+- [ ] Limitations and uncertainty are visible where users could otherwise overinterpret results.
+
+## Breaking change or rollout plan
+
+<!-- Describe migrations, compatibility, rollback, deployment sequence, and post-deployment checks. Write "Not applicable" when appropriate. -->
+
+## Contributor statement
+
+- [ ] I have the right to submit this work and it is compatible with the repository license.
+- [ ] I have read and agree to the prospective contribution terms in `CLA.md` for this contribution.
+- [ ] I have read `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`.
+- [ ] I understand that merge does not by itself mean AWS deployment or real-user validation.

--- a/.github/aoi-app-maintainer-emails.txt
+++ b/.github/aoi-app-maintainer-emails.txt
@@ -1,0 +1,5 @@
+# Authorized Aoi/AImoji Git identities for aoi_kinabot_app/.
+42107224+aoiminamoto@users.noreply.github.com
+aoiminamoto@users.noreply.github.com
+taohin2002@gmail.com
+aoi@aimojitech.com

--- a/.github/blocked-contributor-email-domains.txt
+++ b/.github/blocked-contributor-email-domains.txt
@@ -1,0 +1,3 @@
+# One lowercase domain per line. Pull requests containing an author or committer
+# email from a blocked employer domain fail the contributor-identity check.
+toyota.com

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - dependabot
+  categories:
+    - title: Security and privacy
+      labels:
+        - security
+        - privacy
+    - title: Scoring and data integrity
+      labels:
+        - scoring
+        - data-integrity
+    - title: Features and improvements
+      labels:
+        - enhancement
+    - title: Fixes
+      labels:
+        - bug
+    - title: Documentation and community
+      labels:
+        - documentation
+        - community
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/scripts/check_aoi_app_ownership.py
+++ b/.github/scripts/check_aoi_app_ownership.py
@@ -1,0 +1,78 @@
+"""Allow only authorized Aoi identities to modify aoi_kinabot_app/."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+PROTECTED_PREFIX = "aoi_kinabot_app/"
+
+
+def git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    ).stdout
+
+
+def load_allowed_emails(path: Path) -> set[str]:
+    return {
+        line.strip().lower()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
+def changed_files(commit: str) -> list[str]:
+    return [
+        line.strip()
+        for line in git("diff-tree", "--no-commit-id", "--name-only", "-r", "--root", commit).splitlines()
+        if line.strip()
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("revision_range", help="Git revision range, for example origin/main..HEAD")
+    parser.add_argument(
+        "--allowed-emails",
+        type=Path,
+        default=Path(".github/aoi-app-maintainer-emails.txt"),
+    )
+    args = parser.parse_args()
+
+    allowed = load_allowed_emails(args.allowed_emails)
+    violations: list[tuple[str, str, str]] = []
+    commits = [line for line in git("rev-list", "--reverse", args.revision_range).splitlines() if line]
+    for commit in commits:
+        if not any(path.startswith(PROTECTED_PREFIX) for path in changed_files(commit)):
+            continue
+        author_email = git("show", "-s", "--format=%ae", commit).strip().lower()
+        committer_email = git("show", "-s", "--format=%ce", commit).strip().lower()
+        if author_email not in allowed:
+            violations.append((commit, "author", author_email))
+        if committer_email not in allowed:
+            violations.append((commit, "committer", committer_email))
+
+    if not violations:
+        print("Aoi-maintained application ownership policy passed.")
+        return 0
+
+    print(f"Only authorized Aoi identities may modify {PROTECTED_PREFIX}", file=sys.stderr)
+    for commit, role, email in violations:
+        print(f"- {commit[:12]} {role}: {email}", file=sys.stderr)
+    print(
+        "External contributors may propose changes in issues or patches; Aoi must independently review and submit accepted implementation commits.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check_contributor_emails.py
+++ b/.github/scripts/check_contributor_emails.py
@@ -1,0 +1,77 @@
+"""Reject commits attributed to blocked employer email domains."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def load_blocked_domains(path: Path) -> set[str]:
+    return {
+        line.strip().lower()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
+def commit_identities(revision_range: str) -> list[tuple[str, str, str]]:
+    result = subprocess.run(
+        [
+            "git",
+            "log",
+            revision_range,
+            "--format=%H%x09%ae%x09%ce",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    identities: list[tuple[str, str, str]] = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        commit, author_email, committer_email = line.split("\t", maxsplit=2)
+        identities.append((commit, author_email, committer_email))
+    return identities
+
+
+def email_domain(email: str) -> str:
+    return email.rsplit("@", maxsplit=1)[-1].lower() if "@" in email else ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("revision_range", help="Git revision range, for example origin/main..HEAD")
+    parser.add_argument(
+        "--blocked-domains",
+        type=Path,
+        default=Path(".github/blocked-contributor-email-domains.txt"),
+    )
+    args = parser.parse_args()
+
+    blocked = load_blocked_domains(args.blocked_domains)
+    violations: list[tuple[str, str, str]] = []
+    for commit, author_email, committer_email in commit_identities(args.revision_range):
+        for role, email in (("author", author_email), ("committer", committer_email)):
+            if email_domain(email) in blocked:
+                violations.append((commit, role, email))
+
+    if not violations:
+        print("Contributor email policy passed.")
+        return 0
+
+    print("Contributor email policy failed:", file=sys.stderr)
+    for commit, role, email in violations:
+        print(f"- {commit[:12]} {role}: {email}", file=sys.stderr)
+    print(
+        "Use a personal or authorized project email and recreate the affected commit(s).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/contributor-identity.yml
+++ b/.github/workflows/contributor-identity.yml
@@ -1,0 +1,25 @@
+name: Contributor identity policy
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  check-commit-emails:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Reject blocked employer email domains
+        run: python .github/scripts/check_contributor_emails.py "origin/${{ github.base_ref }}..HEAD"
+      - name: Protect the Aoi-maintained application boundary
+        run: python .github/scripts/check_aoi_app_ownership.py "origin/${{ github.base_ref }}..HEAD"

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+# Canonical contributor identities. This changes generated attribution views;
+# it does not rewrite signed Git history.
+Aoi Minamoto <42107224+aoiminamoto@users.noreply.github.com> Aoi Minamoto (TEMA) <aoi.minamoto@toyota.com>

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,86 @@
+# KinaBot Individual Contributor License Agreement
+
+Version 1.0 — 2026-08-24
+
+This Contributor License Agreement (“Agreement”) applies to contributions
+submitted after this version takes effect in the repository. It does not
+retroactively change rights in earlier contributions. “Project” means the
+KinaBot repository maintained by AImoji LLC. “Contribution” means original
+copyrightable material intentionally submitted by You for inclusion in the
+Project, excluding material clearly marked in writing as “Not a Contribution.”
+
+`aoi_kinabot_app/` has a separate authorship boundary: external contributors may
+propose changes but may not directly author or commit accepted changes in that
+directory. See `CONTRIBUTING.md`.
+
+## 1. Copyright Ownership
+
+You retain ownership of Your Contribution. This Agreement is a license, not a
+copyright assignment.
+
+## 2. Copyright License
+
+You grant AImoji LLC and recipients of software distributed by the Project a
+perpetual, worldwide, non-exclusive, royalty-free, irrevocable copyright license
+to reproduce, prepare derivative works of, publicly display, publicly perform,
+sublicense, and distribute Your Contribution and derivative works of it.
+
+You also authorize AImoji LLC to include and license Your Contribution as part
+of community, source-available, commercial, hosted, or enterprise versions of
+KinaBot under the repository license or other terms selected by AImoji LLC.
+This authorization does not transfer ownership of Your Contribution or prevent
+You from using it elsewhere.
+
+## 3. Patent License
+
+You grant AImoji LLC and recipients of the Project a perpetual, worldwide,
+non-exclusive, royalty-free, irrevocable (except as stated below) patent license
+to make, have made, use, offer to sell, sell, import, and otherwise transfer the
+Project, but only for patent claims You can license that are necessarily
+infringed by Your Contribution alone or by its combination with the Project at
+the time of submission.
+
+If You initiate patent litigation alleging that the Project or a Contribution
+incorporated into it infringes a patent, patent licenses granted to You under
+this Agreement for that Project terminate as of the filing date.
+
+## 4. Your Representations
+
+You represent that:
+
+- You are legally entitled to grant these rights;
+- the Contribution is Your original work or properly identified third-party
+  material submitted with all required permissions and notices;
+- if an employer, school, client, or other party may own or control the work,
+  You have obtained written authorization before submission;
+- You have not included confidential information, personal data, participant
+  audio or transcripts, credentials, trade secrets, or code You lack permission
+  to disclose;
+- You will identify any known license, patent, employment, funding, or conflict
+  that could affect use of the Contribution.
+
+## 5. Support and Warranty
+
+You are not required to provide support. Unless separately agreed in writing,
+Your Contribution is provided “as is,” without warranties or conditions of any
+kind, to the maximum extent permitted by law.
+
+## 6. Attribution and Community Status
+
+The Project may credit Your public contribution but does not promise a specific
+display or placement. Contribution does not make You an employee, contractor,
+partner, agent, or representative of AImoji LLC and does not imply Your
+endorsement of the Project or any commercial offering.
+
+## 7. Acceptance
+
+By opening a pull request or otherwise submitting a Contribution after these
+terms take effect, and affirmatively confirming agreement in the contribution
+workflow, You accept this Agreement. If You contribute on behalf of a legal
+entity, do not use this individual agreement unless You have authority to bind
+that entity; contact aoi@aimojitech.com for an appropriate entity agreement.
+
+This Agreement and its acceptance process should be reviewed by qualified
+intellectual-property counsel before AImoji relies on it for material commercial
+relicensing. The Project must not claim that such legal review has occurred
+until it has actually been documented.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,87 @@
+# KinaBot Community Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in KinaBot a harassment-free experience for
+everyone, regardless of age, body size, visible or invisible disability,
+ethnicity, sex characteristics, gender identity and expression, level of
+experience, education, socioeconomic status, nationality, personal appearance,
+race, caste, color, religion, sexual identity and orientation, or health status.
+
+We pledge to act in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community. Because KinaBot works with voice and language
+data, protecting participant dignity, privacy, consent, and autonomy is a core
+community responsibility.
+
+## Expected Behavior
+
+Examples of behavior that contributes to a positive community include:
+
+- demonstrating empathy, patience, and respect;
+- welcoming questions and helping people learn without gatekeeping;
+- giving and accepting specific, constructive feedback;
+- crediting code, research, design, reports, and other contributions accurately;
+- disclosing limitations, uncertainty, conflicts of interest, and mistakes;
+- using synthetic or properly authorized data and minimizing sensitive details;
+- respecting a person's chosen name, pronouns, language, and boundaries;
+- accepting responsibility, apologizing, and repairing harm when possible.
+
+## Unacceptable Behavior
+
+Unacceptable behavior includes:
+
+- sexualized language or imagery, unwanted attention, or harassment;
+- trolling, insults, threats, intimidation, stalking, or sustained disruption;
+- discrimination or demeaning comments about identity, disability, age, health,
+  language ability, accent, or cognitive status;
+- publishing another person's private information without explicit permission;
+- uploading participant audio, transcripts, credentials, medical information,
+  or other sensitive data to public project spaces;
+- pressuring people to record, share, retain, or analyze their voice;
+- misrepresenting KinaBot outputs as diagnosis, disease prediction, cognitive
+  age, or evidence of clinical improvement or decline;
+- retaliation against someone who raises a good-faith concern;
+- other conduct that would reasonably be considered inappropriate in a
+  professional setting.
+
+## Scope
+
+This Code applies in all KinaBot community spaces and whenever an individual is
+officially representing the project, including GitHub issues, pull requests,
+reviews, discussions, events, research activities, and private project
+communications.
+
+## Reporting and Enforcement
+
+Report conduct concerns privately to **aoi@aimojitech.com**. Do not use a public
+issue when a report contains sensitive personal information. Include the URLs,
+dates, context, and supporting evidence needed to understand the concern, while
+sharing no more private data than necessary.
+
+The maintainer will acknowledge and review reports as capacity allows, protect
+the reporter's privacy to the extent reasonably possible, avoid conflicts of
+interest, and document enforcement decisions privately. If the maintainer is
+the subject of a report or cannot review it impartially, the reporter may ask
+for an independent reviewer acceptable to both parties. Absolute
+confidentiality cannot be promised where disclosure is required to prevent
+harm or comply with law.
+
+Maintainers may take actions proportionate to context and impact, including:
+
+1. **Correction** — a private or public explanation and request to change.
+2. **Warning** — a documented warning with consequences for continued conduct.
+3. **Temporary restriction** — time-limited removal from project interaction.
+4. **Permanent restriction** — removal from community spaces for sustained,
+   severe, or dangerous behavior.
+
+Good-faith disagreement, technical criticism, and reporting mistakes are not
+violations. Knowingly false or retaliatory reports may themselves violate this
+Code. Enforcement decisions may be reconsidered when material new information
+is provided.
+
+## Attribution
+
+This policy is adapted from the [Contributor Covenant, version
+2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html),
+available under the [Creative Commons Attribution 4.0
+License](https://creativecommons.org/licenses/by/4.0/).

--- a/COMMERCIAL-LICENSING.md
+++ b/COMMERCIAL-LICENSING.md
@@ -1,0 +1,46 @@
+# Commercial Licensing
+
+KinaBot's public repository is intended for permitted personal, academic, and
+non-profit research use. Commercial use is not granted by the public license.
+
+Organizations interested in commercial evaluation, integration, hosting,
+distribution, support, or other revenue-related use should contact:
+
+**AImoji LLC**  
+**aoi@aimojitech.com**  
+Subject: **KinaBot commercial licensing request**
+
+Please include only non-confidential information in the initial request:
+
+- organization and contact name;
+- intended users and use case;
+- components and version requested;
+- hosted, internal, embedded, distributed, or research deployment model;
+- expected geography and approximate scale;
+- whether modifications, support, or AWS hosting are requested;
+- target timeline.
+
+Sending a request, receiving repository access, evaluating the public code, or
+discussing terms does not grant commercial permission. Permission exists only
+after an authorized written agreement is signed.
+
+## Possible Commercial Offerings
+
+Depending on product maturity, rights ownership, safety review, and a separate
+agreement, AImoji may offer:
+
+- official hosted KinaBot service;
+- enterprise deployment, integration, and migration support;
+- operational monitoring, backup/restore, and service commitments;
+- training, customization, and technical support;
+- commercial redistribution or embedding rights.
+
+This page is not a price list, offer, warranty, service-level agreement, or
+promise that a use case will be approved. Clinical, surveillance, coercive,
+employment, insurance, or other high-impact use is not authorized merely by
+paying a fee and may remain prohibited.
+
+Commercial terms cannot grant rights in third-party dependencies, content,
+models, datasets, historical contributions, or trademarks that AImoji does not
+own or control. Customers are responsible for independent legal, security,
+privacy, regulatory, and institutional review.

--- a/COMMUNITY-AND-COMMERCIAL.md
+++ b/COMMUNITY-AND-COMMERCIAL.md
@@ -1,0 +1,65 @@
+# Community and Commercial Edition Boundary
+
+KinaBot uses a source-available community model. This boundary keeps public
+benefit, community participation, commercial sustainability, and product claims
+separate and understandable.
+
+## Community Repository
+
+The public repository is the transparent engineering and learning surface for:
+
+- the maintained speech-sample feature engine and participant experience;
+- scoring definitions, limitations, model-version behavior, and regression tests;
+- privacy-aware and offline/private research patterns;
+- public documentation, issue discussion, and reproducible learning cases;
+- community contributions accepted under the contribution terms.
+
+The `aoi_kinabot_app/` product area remains authored and committed only by Aoi.
+External issue reports, research, designs, testing, and patch proposals can
+inform that application and must receive accurate credit, but Aoi independently
+reviews and submits accepted product changes.
+
+Availability in this repository does not grant commercial use beyond
+`LICENSE.md` and does not establish clinical validation, institutional approval,
+production fitness, or a support commitment.
+
+## Possible AImoji Commercial Services
+
+AImoji may separately offer services or licensed capabilities such as:
+
+- official AWS hosting and managed upgrades;
+- organization administration, enterprise identity, and audit tooling;
+- deployment, integration, migration, training, and support;
+- operational monitoring, backup/restore, incident response, and service terms;
+- customer-specific features or integrations developed under contract.
+
+No item is promised until it is documented in a signed agreement. Commercial
+features must not weaken consent, deletion, privacy, security, accessibility, or
+responsible-use boundaries.
+
+## What Is Never Implied
+
+- Community contributors do not automatically endorse commercial offerings.
+- A merged contribution does not make the contributor an AImoji employee,
+  contractor, partner, or representative.
+- A public feature is not automatically included in a supported commercial
+  service.
+- A commercial agreement does not convert KinaBot into a medical device or
+  authorize diagnosis, surveillance, coercion, or high-impact decisions.
+- Public issue discussion is not an appropriate place for confidential customer
+  or participant information.
+
+## Decision Records
+
+Material movement between community and commercial components should be
+documented with:
+
+1. the user and business rationale;
+2. ownership and license review;
+3. effects on contributors and existing users;
+4. privacy, security, accessibility, migration, and responsible-use analysis;
+5. version, release, deployment, and rollback implications.
+
+The project should not remove a previously granted license from copies already
+received under that license. Future licensing changes must be prospective,
+versioned, and clearly announced.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,26 @@ Before starting substantial work:
 3. Wait for maintainer alignment before investing in a large feature or changing
    scoring, data handling, consent, safety wording, dependencies, or architecture.
 
+By submitting a contribution outside the protected Aoi-maintained application
+boundary, you must read and affirmatively accept [`CLA.md`](CLA.md). Contact the
+maintainer before submitting on behalf of a company or other legal entity.
+
 Small documentation corrections and narrowly scoped bug fixes may go directly
 to a pull request when the problem and solution are clear.
+
+### Aoi-maintained application boundary
+
+`aoi_kinabot_app/` is the independently maintained KinaBot product area. Only
+Aoi, using an approved personal or AImoji project identity, may author and
+commit changes in that directory. External contributors are welcome to report
+issues, supply reproducible evidence, review behavior, and propose patches, but
+accepted implementation must be independently reviewed and submitted by Aoi.
+
+This boundary preserves product responsibility and authorship provenance. It
+must not be used to erase or under-credit the person who discovered a problem,
+designed a solution, supplied research, or provided review. Those contributions
+should be credited in the issue, decision record, pull request, or release notes
+with permission.
 
 ## Choose the Right Contribution
 
@@ -125,6 +143,12 @@ Never commit `.env` files, cloud credentials, API keys, participant data,
 generated local databases, or production exports. Use synthetic data in tests
 and examples.
 
+Use a personal email address or an email address you are explicitly authorized
+to use for this project in Git author and committer metadata. Do not use an
+unrelated employer, university, customer, or third-party domain. Pull requests
+containing a blocked employer domain fail the contributor-identity check; amend
+or recreate the affected commits before requesting review.
+
 ## Make a Focused Change
 
 1. Fork the repository and create a branch from the latest `main`.
@@ -212,6 +236,9 @@ By contributing, you confirm that:
 - it may be distributed under this repository's license; and
 - it contains no confidential, proprietary, medical, or personal data that you
   lack permission to share.
+
+The prospective rights grant and commercial-relicensing terms are defined in
+[`CLA.md`](CLA.md); this summary does not replace that agreement.
 
 We recognize non-code contributions as well as merged code. GitHub records issue
 authors, pull-request authors, reviewers, and commits; release notes or project

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,11 @@
-Non-Commercial License Agreement
+KinaBot Non-Commercial Source License
 
-Copyright © AIMOJI LLC. All rights reserved.
+Copyright © the respective copyright holders. All rights reserved except as
+expressly granted below.
+
+This license applies only to material whose copyright holder has made it
+available under these terms. Third-party software, content, models, datasets,
+and separately identified materials remain subject to their own licenses.
 
 Permission is hereby granted to any person obtaining a copy of this software
 and associated documentation files (the “Software”) to use, copy, modify, and
@@ -23,3 +28,7 @@ Software.
 
 For licensing inquiries or commercial usage, please contact:
 aoi@aimojitech.com 
+
+Plain-language guidance and commercial-contact information are available in
+LICENSING.md and COMMERCIAL-LICENSING.md. Those explanatory documents do not
+replace or expand this license.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,73 @@
+# KinaBot Licensing Guide
+
+This guide explains the project's intended licensing model in plain language.
+It is not legal advice and does not replace the controlling terms in
+[`LICENSE.md`](LICENSE.md), third-party notices, or a signed commercial
+agreement.
+
+## Current Model
+
+KinaBot is **source-available**, not OSI-approved open-source software. The
+repository's current license permits personal, academic-research, and
+non-profit-research use, but commercial use requires prior written permission
+from the relevant rights holder.
+
+The restriction on commercial use means the project must not be described as
+“open source” under the Open Source Initiative definition. Public source code,
+free access, and community contribution do not by themselves make a license
+open source.
+
+## Community Use
+
+Subject to `LICENSE.md`, community users may use, study, modify, and publish the
+software for the permitted non-commercial purposes. Examples may include:
+
+- personal learning and experimentation;
+- classroom teaching and student projects;
+- academic or non-profit research without commercial advantage.
+
+The license text—not this summary—controls. University-industry projects,
+consulting, sponsored research, paid services, internal company evaluation,
+fundraising activity, and use by a commercial entity may require clarification
+or a commercial license even when no end user is directly charged.
+
+## Commercial Use
+
+Do not assume that public availability grants commercial rights. Commercial use
+requires a separate written agreement. See
+[`COMMERCIAL-LICENSING.md`](COMMERCIAL-LICENSING.md) for the request process.
+
+A commercial agreement may cover only the code, trademarks, services, and other
+rights that the licensor has authority to grant. Third-party software and
+historical contributions remain subject to their own rights and notices.
+
+## Contributions
+
+Contributors keep ownership of their original contributions. New contributions
+must be submitted under the repository's contribution terms and the
+[`CLA.md`](CLA.md). This is intended to let the project publish contributions in
+the community edition and, where authorized, offer commercial licensing without
+removing contributor attribution.
+
+The CLA is prospective: it does not retroactively change rights in an earlier
+contribution. See [`PROVENANCE.md`](PROVENANCE.md) for the repository's current
+rights audit and unresolved review items.
+
+## Trademarks
+
+Code permission does not automatically grant permission to use the KinaBot or
+AImoji names, logos, or official identity. See [`TRADEMARKS.md`](TRADEMARKS.md).
+
+## Before Relying on This Model
+
+A qualified intellectual-property attorney should review:
+
+- ownership and employment/contract obligations for existing code;
+- rights in historical third-party contributions;
+- the custom non-commercial license and its enforceability by jurisdiction;
+- the CLA acceptance mechanism and commercial-relicensing grant;
+- trademark ownership and registration;
+- third-party dependency, model, dataset, and content licenses.
+
+Until that review is complete, the repository must not claim that its licensing
+or commercial-rights chain has been legally validated.

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,0 +1,57 @@
+# Authorship and Rights Provenance
+
+Last reviewed: 2026-08-24
+
+This record separates observable Git history from legal conclusions. It is an
+engineering audit, not a determination of copyright ownership or legal advice.
+
+## Maintained Application
+
+Git history currently attributes commits under `aoi_kinabot_app/` to Aoi
+Minamoto identities. The project policy now permits only approved Aoi personal
+or AImoji project identities to author and commit changes in that directory.
+External reports, research, design, testing, and patch proposals must still
+receive accurate non-code credit.
+
+Commit `751ecd368ccb6f82ba13bd60ad1c1e7afd0e6418` was recorded with the author
+identity `Aoi Minamoto (TEMA) <aoi.minamoto@toyota.com>`. The maintainer identifies
+this as an unintended Git metadata selection, not a Toyota contribution,
+sponsorship, affiliation, or endorsement. `.mailmap` maps generated contributor
+views to Aoi's canonical GitHub identity while the immutable commit object is
+retained for audit integrity.
+
+This factual correction does not by itself resolve any employment or copyright
+question. The maintainer should privately retain evidence that the work was
+independently created and authorized, and seek counsel if commercial licensing
+relies materially on it.
+
+## Historical Repository Materials
+
+Repository-root history includes commits attributed to Aoi Minamoto, Yuan Chen,
+and IreneLi. Those historical exploratory materials must not be represented as
+solely authored or solely owned by AImoji without documented rights evidence.
+The public Git history remains the attribution record unless corrected by the
+relevant contributor or another reliable source.
+
+## Prospective Contributions
+
+- `CONTRIBUTING.md` defines submission and identity rules.
+- `CLA.md` applies prospectively after adoption and affirmative acceptance.
+- `CODEOWNERS` identifies required maintainers but does not transfer copyright.
+- CI blocks specified unrelated employer domains and unauthorized commit
+  identities in `aoi_kinabot_app/`.
+
+## Review Before Commercial Reliance
+
+Before offering a commercial license that includes historical or externally
+contributed material, review:
+
+- the license present when each contribution was submitted;
+- pull-request text, contributor agreements, and employer authorization;
+- third-party dependencies, copied content, datasets, models, and assets;
+- whether a component can be licensed by AImoji or must retain separate terms;
+- whether independent reimplementation or contributor permission is required.
+
+Do not alter public Git history merely to create the appearance of cleaner
+ownership. Correct display metadata with `.mailmap`, preserve evidence, and
+document legal resolution separately.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ This repository preserves earlier exploratory work and product-direction discuss
 
 Current Aoi-maintained development is in `aoi_kinabot_app/`.
 
+## Participate
+
+KinaBot welcomes code, tests, documentation, translation, accessibility review,
+privacy review, reproducible research, issue triage, and product feedback.
+
+- [Contributing guide](CONTRIBUTING.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Security and private vulnerability reporting](SECURITY.md)
+- [Product and engineering roadmap](ROADMAP.md)
+- [Release process](RELEASING.md)
+- [Current application changelog](aoi_kinabot_app/CHANGELOG.md)
+- [Licensing guide](LICENSING.md) and [commercial licensing](COMMERCIAL-LICENSING.md)
+- [Community/commercial boundary](COMMUNITY-AND-COMMERCIAL.md)
+- [Contributor agreement](CLA.md), [trademark policy](TRADEMARKS.md), and
+  [authorship provenance](PROVENANCE.md)
+
+Start with a scoped [issue](https://github.com/usekina/kina/issues/new/choose)
+or review tasks labeled [`good first issue`](https://github.com/usekina/kina/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22).
+
 KinaBot V1 does not use cognitive age, biological age, dementia risk, medical risk labels, or diagnosis-like composite scores. V1 focuses on separate speech and language feature scores, trend reflection, consent-first access, and privacy-aware data handling.
 
 Please treat files outside `aoi_kinabot_app/` as historical exploratory materials unless otherwise stated.
@@ -119,6 +138,10 @@ KinaBot is an early-stage source-available public-benefit project for research, 
 
 ## License
 
-This repository uses a non-commercial license. Personal, academic, and non-profit research use is allowed under the license terms. Commercial use requires prior written permission.
+This repository currently uses a custom non-commercial source-available
+license. Personal, academic, and non-profit research use is allowed under its
+terms. Commercial use requires prior written permission. Because the license
+restricts fields of use, it is not an OSI-approved open-source license; please
+describe the current project as **source-available**, not OSI open source.
 
 See [LICENSE.md](LICENSE.md) for details.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,81 @@
+# Releasing KinaBot
+
+This document defines how maintainers turn reviewed changes into an auditable
+release. It does not authorize deployment or replace the AWS operations guide.
+
+## Versioning
+
+Use semantic versioning for application releases:
+
+- **MAJOR** for intentionally incompatible user, API, or persisted-data changes;
+- **MINOR** for backward-compatible features;
+- **PATCH** for backward-compatible fixes and documentation corrections that
+  materially affect safe use.
+
+Scoring-model identifiers are versioned separately from application releases.
+Any incompatible scoring change must receive a new scoring-model identifier and
+must not be silently mixed with older scores in trends.
+
+## Release Readiness
+
+Before tagging a release:
+
+1. confirm all intended pull requests are merged and CI passes on `main`;
+2. review open high-severity security, privacy, data-loss, and scoring-accuracy
+   issues;
+3. update `aoi_kinabot_app/CHANGELOG.md` under an explicit version and date;
+4. document migrations, configuration or dependency changes, rollback, and AWS
+   operational impact;
+5. verify temporary-audio cleanup, consent, authentication, deletion, core
+   scoring, history-version separation, and supported multilingual flows;
+6. confirm documentation and responsible-use wording match runtime behavior;
+7. use synthetic data for evidence and remove secrets and personal information;
+8. identify contributors from merged pull requests and material issue reports.
+
+## Release Notes
+
+Release notes should be understandable without reading commit history and use
+these sections when applicable:
+
+- Highlights
+- Added
+- Changed
+- Fixed
+- Privacy and security
+- Scoring and migration
+- Accessibility and multilingual behavior
+- Deployment and operator action required
+- Known limitations
+- Contributors
+
+Do not claim deployment, accessibility conformance, institutional approval,
+clinical validation, or measured impact unless the release links evidence that
+supports the exact claim.
+
+## Tag and Publish
+
+1. Create an annotated tag such as `v1.2.0` from the reviewed `main` commit.
+2. Generate a draft GitHub release and edit it into the structure above.
+3. Link the changelog, migration instructions, relevant issues, and pull
+   requests.
+4. Publish only after another reviewer or the maintainer verifies the tag,
+   artifacts, dependencies, and claims.
+5. Record deployment separately. If deployed to AWS, capture the environment,
+   release/tag, timestamp, health check, smoke tests, rollback point, and known
+   limitations without exposing infrastructure secrets.
+
+## Contributor Recognition
+
+Thank code and non-code contributors for material, attributable work, including
+bug reports, design, tests, documentation, translation, accessibility review,
+privacy review, and research feedback. Ask before publishing a real name or
+sensitive affiliation; GitHub usernames may be used for public GitHub activity.
+Recognition must not imply endorsement of the entire project.
+
+## Correction and Withdrawal
+
+If a release contains a security, privacy, data-loss, or scoring-integrity risk,
+prioritize user protection. Mark affected notes clearly, publish mitigation or a
+replacement release, and document whether operators must rotate secrets,
+migrate data, redeploy, or notify affected users. Do not rewrite release history
+in a way that hides the incident or original behavior.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,33 +1,116 @@
-# KinaBot Roadmap
+# KinaBot Product and Engineering Roadmap
 
-## Phase 1: Trust And Safety Foundation
+Last reviewed: 2026-08-24
 
-- Public README with clear responsible-use boundary
-- Medical disclaimer
-- Privacy explanation
-- Security policy
-- Consent-first positioning
-- Remove or avoid high-risk medical claims
+This roadmap communicates direction, not a promise of delivery, funding,
+clinical effectiveness, institutional approval, or regulatory status. Priorities
+may change as evidence, risk, maintainer capacity, and user needs change.
 
-## Phase 2: Safer Web Prototype
+## Product North Star
 
-- Replace medical-sounding UI wording
-- Remove estimated cognitive age
-- Use communication pattern summaries instead of diagnosis-like scores
-- Add consent notice before recording
-- Clarify whether audio is saved
-- Provide safer PDF report wording
+Help people reflect on observable patterns in a speech sample over time while
+protecting dignity, consent, privacy, accessibility, and honest interpretation.
+KinaBot feature indexes are descriptive engineering measures, not health scores,
+diagnoses, disease predictions, cognitive age, or evidence of improvement or
+decline.
 
-## Phase 3: Privacy-Aware Data Handling
+## Current Commitments
 
-- Give users control over saving or deleting recordings
-- Prefer minimal data retention
-- Support local or approved transcription options
-- Add clear data-flow documentation
+These are the areas the maintained application is expected to protect on every
+change:
 
-## Phase 4: Future Applications
+- explicit consent and understandable non-clinical language;
+- minimal collection, temporary-audio cleanup, retention transparency, and
+  participant deletion controls;
+- versioned and explainable English, Japanese, and Chinese feature scoring;
+- separation of incompatible scoring versions in longitudinal trends;
+- mobile-first participant results and accessible interaction patterns;
+- offline/private research workflows that do not silently call cloud AI;
+- synthetic test data, regression coverage, and reproducible engineering checks;
+- clear separation between engineering verification and user, institutional,
+  clinical, or regulatory validation.
 
-- Mobile experience
-- Family/caregiver sharing with consent
-- Longitudinal communication pattern tracking
-- Clinician-reviewed study design if medical claims are ever considered
+## Now — Reliability and Trust Foundation
+
+Work may be selected from these priorities when it has a scoped issue and an
+owner:
+
+- close remaining authentication, consent, deletion, and retention gaps;
+- strengthen automated privacy-boundary and failure-cleanup tests;
+- improve accessibility checks for keyboard, screen reader, contrast, motor,
+  hearing, language, and low-literacy needs;
+- make scoring definitions, model versions, raw metrics, and migration behavior
+  auditable;
+- improve production health checks, structured logs, backup/restore evidence,
+  dependency review, and rollback instructions;
+- validate mobile upload and results journeys on supported browsers and devices;
+- keep contributor, security, release, and responsible-use documentation current.
+
+## Next — Evidence and Interoperability
+
+These directions require discovery or validation before being treated as
+committed implementation:
+
+- moderated usability research with smartphone users, including older adults;
+- transparent measurement of task completion, comprehension, accessibility,
+  retention behavior, and failure recovery;
+- documented export schemas and compatibility guarantees for approved research;
+- calibration datasets and language-specific error analysis using properly
+  authorized, governed data;
+- a dedicated responsive research-admin experience if validated workflows
+  justify it;
+- community-maintained translations with native-speaker review and explicit
+  limitations;
+- sustainable release cadence, maintainer coverage, and contribution pathways.
+
+## Explore — Evidence Required
+
+Exploration does not imply approval or planned delivery:
+
+- progressive web or native mobile delivery, only if mobile web cannot satisfy a
+  validated user need and the added privacy/security surface has an owner;
+- consent-based sharing with a chosen family member, caregiver, or professional;
+- privacy-preserving aggregate research workflows;
+- additional languages after language-specific tokenization, validation, and
+  documentation resources are available;
+- integrations that preserve user control, data minimization, deletion, and
+  responsible interpretation.
+
+## Not Planned Without a New Evidence and Governance Basis
+
+- medical diagnosis, dementia or disease-risk prediction;
+- cognitive-age, biological-age, impairment, or clinical-progression labels;
+- treatment recommendations or replacement of healthcare professionals;
+- hidden recording, surveillance, coercive monitoring, or passive monitoring;
+- employment, insurance, eligibility, or other high-impact decisions;
+- public leaderboards, interpersonal ranking, streak penalties, or shame-based
+  engagement;
+- default retention of raw audio or full transcripts;
+- mixing incompatible score-model versions in a single continuous trend;
+- claims of safety, accessibility, clinical value, or impact without evidence.
+
+## How Work Enters the Roadmap
+
+A roadmap proposal should include:
+
+1. a defined user and evidence-backed problem;
+2. measurable acceptance criteria and explicit non-goals;
+3. privacy, security, accessibility, multilingual, migration, and maintenance
+   analysis;
+4. an owner and realistic validation method;
+5. an issue or decision record that makes uncertainty and tradeoffs visible.
+
+Priority is based on user harm or benefit, urgency, strategic fit, confidence,
+effort, operational cost, and responsible-use risk. A merged pull request is not
+proof of deployment or real-world impact.
+
+## Status Language
+
+- **Committed:** expected to be protected or delivered once explicitly scoped.
+- **Next:** valuable candidate awaiting capacity, evidence, or implementation.
+- **Explore:** a question to investigate, not a promise.
+- **Not planned:** outside current boundaries unless the evidence and governance
+  basis materially changes.
+
+Use GitHub issues and pull requests for live implementation status. Update the
+`Last reviewed` date and link supporting evidence when this roadmap changes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,37 +1,108 @@
-# Security Policy
+# Security and Privacy Policy
 
-KinaBot handles sensitive voice and language data. Security issues should be reported responsibly so users and families can be protected.
+KinaBot processes sensitive voice and language data. Coordinated disclosure
+helps protect participants, researchers, deployers, and the wider community.
 
-## Supported Project Status
+## Supported Versions
 
-KinaBot is an early-stage prototype. Security improvements are prioritized for the current `main` branch.
+KinaBot is an early-stage project. Security fixes are made for the current
+`main` branch and the production version identified in the latest release or
+deployment record. Historical prototypes and older releases may not receive
+fixes. If you operate a deployment, keep your version and dependencies current.
 
-## Reporting A Vulnerability
+| Version | Supported |
+| --- | --- |
+| Current `main` / latest release | Yes |
+| Older releases and historical prototypes | No |
 
-If you discover a security or privacy vulnerability, please do not open a public GitHub issue with sensitive details.
+This table describes maintenance coverage, not a guarantee that a version is
+free of vulnerabilities or suitable for clinical, safety-critical, or
+high-risk use.
 
-Instead, contact the project maintainer directly:
+## Report Privately
 
-- Email: aoi@aimojitech.com
+Do **not** open a public issue for an unpatched vulnerability, exposed secret,
+or incident containing personal data.
 
-Please include:
+Preferred channel:
 
-- A clear description of the issue
-- Steps to reproduce, if possible
-- The affected file, feature, or deployment pattern
-- Whether sensitive voice, transcript, report, or user data may be exposed
+1. Use GitHub **Report a vulnerability** on the repository Security tab when
+   private vulnerability reporting is available.
+2. Otherwise email **aoi@aimojitech.com** with the subject
+   `[KinaBot Security] Brief description`.
 
-## Security Priorities
+If email encryption is required, first request a suitable secure exchange
+method without including exploit details or sensitive data. Never send real
+participant audio, full transcripts, passwords, API keys, access tokens, or
+production database exports as proof. Use redacted logs and synthetic samples.
 
-Important areas include:
+Include, when available:
 
-- Unauthorized access to recordings or transcripts
-- Accidental long-term storage of sensitive audio
-- Hidden recording or unclear consent flows
-- Exposure of generated reports
-- Dependency vulnerabilities
-- Misconfiguration in public deployments
+- affected version, commit, component, and deployment mode;
+- vulnerability type and realistic impact;
+- minimal reproducible steps or proof of concept;
+- prerequisites and whether exploitation is remote or authenticated;
+- evidence of possible exposure of audio, transcripts, reports, identity,
+  consent records, secrets, or research data;
+- suggested mitigation and any disclosure deadline;
+- how you would like to be credited, or whether you prefer anonymity.
 
-## Responsible Use
+## What to Expect
 
-KinaBot should not be used for surveillance, hidden recording, coercive monitoring, employment decisions, insurance decisions, or any use that harms user dignity, privacy, or autonomy.
+Maintainers will make a good-faith effort to:
+
+- acknowledge a complete report as capacity allows;
+- confirm whether the issue is reproducible and in scope;
+- communicate material changes in status;
+- coordinate a fix and public advisory when appropriate;
+- credit the reporter with permission.
+
+Response and remediation times depend on severity, reproducibility, maintainer
+capacity, and third-party dependencies; this volunteer-stage project does not
+promise a fixed service-level agreement. Please allow a reasonable private
+coordination period before public disclosure. If users face active harm, data
+exposure, or credential compromise, prioritize containment and notify affected
+operators through the safest available channel.
+
+## In-Scope Examples
+
+- unauthorized access to accounts, recordings, transcripts, reports, or exports;
+- bypasses of authentication, consent, retention, or deletion controls;
+- temporary audio or transcript persistence after success or failure;
+- predictable participant identifiers or broken pseudonymization;
+- injection, path traversal, unsafe upload handling, or remote code execution;
+- exposed secrets, insecure AWS configuration, or overly broad permissions;
+- dependency vulnerabilities with a demonstrated KinaBot impact;
+- privacy failures that disclose or silently retain sensitive data.
+
+## Usually Out of Scope
+
+- reports based only on automated scanner output without a reproducible impact;
+- denial-of-service requiring unrealistic resources against a local prototype;
+- social engineering, physical access, or attacks on unrelated third parties;
+- missing hardening headers with no demonstrated security consequence;
+- vulnerabilities that affect only unsupported historical code;
+- clinical-effectiveness, diagnosis, or regulatory claims—KinaBot makes no such
+  claims, though misleading product wording may still be reported publicly as a
+  safety issue when it contains no exploit or private data.
+
+These examples guide triage and do not prevent maintainers from investigating a
+credible good-faith concern.
+
+## Safe-Harbor Intent
+
+The project supports good-faith research that avoids privacy violations,
+service disruption, data destruction, persistence, extortion, and access beyond
+what is necessary to demonstrate the issue. Stop testing and report immediately
+if you encounter personal data, credentials, or evidence of active compromise.
+
+This statement expresses project intent and is not legal advice or authorization
+to test systems, accounts, data, or infrastructure you do not own or have
+explicit permission to assess.
+
+## Responsible-Use Boundary
+
+KinaBot must not be used for surveillance, hidden recording, coercive
+monitoring, employment or insurance decisions, diagnosis, or other uses that
+undermine dignity, privacy, consent, or autonomy. Security review does not make
+the software clinically validated or suitable for high-risk decisions.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,60 @@
+# KinaBot Trademark Policy
+
+The KinaBot and AImoji names, logos, visual identity, and source-identifying
+assets distinguish official project and company work. Publication of source
+code does not grant a trademark license or permission to imply endorsement.
+
+This policy applies whether or not a mark is registered in a particular
+jurisdiction. It does not determine legal ownership by itself and should be
+reviewed alongside applicable trademark law.
+
+## Uses That Generally Do Not Require Permission
+
+You may truthfully:
+
+- refer to the official KinaBot project;
+- link to the repository;
+- state that a project is compatible with, based on, or a fork of KinaBot;
+- use the word mark in news, research, commentary, comparison, or teaching;
+- retain legally required attribution and notices.
+
+These uses must be accurate, non-confusing, and no more prominent than necessary
+to identify the project. For example: “Independent project based on KinaBot; not
+affiliated with or endorsed by AImoji LLC.”
+
+## Uses Requiring Written Permission
+
+Written permission is required to:
+
+- name a product, company, service, domain, application, or event “KinaBot” or
+  something confusingly similar;
+- use official logos, icons, product dress, or badges in a way that suggests an
+  official distribution, partnership, certification, or endorsement;
+- market paid hosting, consulting, training, or other commercial services using
+  the marks as the primary brand;
+- register a domain name, social account, app-store listing, or trademark that
+  contains or imitates a protected project mark;
+- claim that a fork or deployment is the official KinaBot service.
+
+## Forks and Modified Versions
+
+Forks must use a clearly different product name and visual identity. They may
+preserve copyright and license notices and accurately acknowledge that they are
+based on KinaBot, but must not create confusion about source, support, security,
+privacy practices, clinical status, or affiliation.
+
+## No Certification or Clinical Endorsement
+
+Use of a mark never establishes clinical validation, regulatory approval,
+accessibility conformance, security certification, institutional approval, or
+suitability for diagnosis or high-impact decisions.
+
+## Reporting and Permission
+
+For permission requests or confusing uses, contact **aoi@aimojitech.com** with
+the proposed wording, visual, channel, geography, duration, and commercial
+context. Permission must be explicit and written.
+
+Nothing in this policy limits uses permitted by applicable law, including fair
+use or nominative reference. This policy is not legal advice; AImoji should
+obtain trademark counsel before relying on it for enforcement or registration.

--- a/aoi_kinabot_app/CHANGELOG.md
+++ b/aoi_kinabot_app/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+All notable changes to the current Aoi-maintained KinaBot application are
+recorded here. Historical repository-root prototypes are outside this
+changelog. Entries distinguish shipped engineering changes from deployment,
+user-research, institutional, clinical, or regulatory claims.
+
+## 2026-08-24 · Community governance foundation
+
+- Added a project Code of Conduct, expanded security and privacy disclosure
+  policy, structured Issue Forms, and a responsible-use pull request checklist.
+- Defined roadmap status language, release readiness, contributor recognition,
+  and honest licensing terminology for the current source-available project.
+
 ## 2026-08-24 · Kina orange product interface
 
 - Introduced the Kina orange-red product accent for primary actions, recording,
@@ -98,10 +110,6 @@
 - Temporarily disabled in-browser recording after unreliable mobile-browser
   behavior was observed. The interface now clearly marks direct recording as
   coming soon and uses the stable audio-file upload flow.
-
-All notable changes to the current Aoi-maintained KinaBot application are
-recorded here. Historical repository-root prototypes are outside this
-changelog.
 
 ## [1.1.0] - Unreleased
 


### PR DESCRIPTION
## Summary

- establish KinaBot as an accurately described source-available community project;
- add Code of Conduct, expanded security policy, Issue Forms, PR template, CODEOWNERS, roadmap, release governance, and contributor recognition;
- document community versus commercial boundaries, commercial-license requests, trademarks, provenance, and prospective contributor terms;
- correct one historical Aoi/Toyota email display through `.mailmap` without rewriting Git history;
- block future `@toyota.com` commit metadata and limit `aoi_kinabot_app/` authorship/commits to approved Aoi personal or AImoji identities;
- add release-note categories and create a genuinely scoped good first issue (#44).

## Licensing decision

This PR deliberately does **not** adopt Apache-2.0. KinaBot remains under its non-commercial source-available license because the maintainer requires commercial use to obtain written permission. README and licensing materials no longer describe that model as OSI open source.

The CLA, custom license, commercial-rights chain, trademark position, and acceptance mechanism are explicitly marked for qualified legal review. This PR does not claim that review has occurred.

## Authorship boundary

`aoi_kinabot_app/` remains independently authored and committed only by Aoi using an approved personal or AImoji identity. External contributors may provide issues, evidence, research, review, and patch proposals and must receive accurate credit, but Aoi independently submits accepted product changes.

The historical commit `751ecd3` used `aoi.minamoto@toyota.com` in Git metadata. The maintainer identifies this as an unintended identity selection, not a Toyota contribution or endorsement. Original Git evidence is preserved.

## Verification

- `git diff --check`
- Python syntax compilation for both contributor-policy scripts
- positive contributor-email and Aoi-app ownership checks on this PR range
- negative checks confirm commit `751ecd3` is rejected by both policies
- `.mailmap` canonical identity verified with `git check-mailmap`
- GitHub labels created for triage, privacy, safety, security, scoring, data integrity, community, and changelog control
- good first issue #44 revised to remain outside the protected application directory

## Impact

- No scoring, runtime, database, authentication, privacy processing, or AWS configuration changed.
- Documentation and GitHub governance only.
- Existing immutable Git history is not rewritten.
