### PR TITLE
Unify multilingual score history by account

### DIFF
--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -482,6 +482,14 @@ HISTORY_COPY = {
         "progress": "{count} of 3 sessions completed. Trends begin after session 3.",
         "recent": "Recent sessions",
         "all": "All sessions",
+        "mixed_languages": (
+            "This account history combines recordings from every selected language. "
+            "Language-specific scoring baselines can make cross-language differences less comparable."
+        ),
+        "mixed_versions": (
+            "This history includes more than one scoring-model version. Earlier sessions remain "
+            "visible, but direct comparisons across model versions should be interpreted cautiously."
+        ),
         "change": "Observed change since the first sample",
         "higher": "Higher in latest sample",
         "lower": "Lower in latest sample",
@@ -505,6 +513,14 @@ HISTORY_COPY = {
         "progress": "3回中{count}回完了しました。3回目からトレンドを表示します。",
         "recent": "最近のセッション",
         "all": "すべてのセッション",
+        "mixed_languages": (
+            "このアカウントでは、選択したすべての言語の記録をまとめて表示しています。"
+            "言語ごとの採点基準が異なるため、言語をまたぐ差は単純比較できない場合があります。"
+        ),
+        "mixed_versions": (
+            "この履歴には複数の採点モデル版が含まれます。以前の記録も表示されますが、"
+            "異なる版のスコアを直接比較する場合は注意が必要です。"
+        ),
         "change": "最初のサンプルからの変化",
         "higher": "最新サンプルで高い",
         "lower": "最新サンプルで低い",
@@ -527,6 +543,14 @@ HISTORY_COPY = {
         "progress": "已完成3次中的{count}次，第3次开始显示趋势。",
         "recent": "最近记录",
         "all": "全部记录",
+        "mixed_languages": (
+            "此账户历史合并显示所有已选择语言的记录。不同语言使用各自的评分基准，"
+            "因此跨语言分数差异不一定可以直接比较。"
+        ),
+        "mixed_versions": (
+            "此历史包含多个评分模型版本。旧记录仍会显示，但直接比较不同版本的分数时"
+            "需要谨慎解释。"
+        ),
         "change": "与第一次样本相比的变化",
         "higher": "最近一次较高",
         "lower": "最近一次较低",
@@ -926,9 +950,7 @@ primary_view = st.radio(
 
 if primary_view == "trends":
     assign_timezone_to_legacy_sessions(st.session_state.user_id, browser_timezone)
-    rows = get_user_scores(
-        st.session_state.user_id, scoring_model_version=SCORING_MODEL_VERSION
-    )
+    rows = get_user_scores(st.session_state.user_id)
     st.subheader(history_copy["trends"])
     if not rows:
         st.caption(history_copy["no_scores"])
@@ -936,6 +958,10 @@ if primary_view == "trends":
 
     history = pd.DataFrame([dict(row) for row in rows])
     session_count = int(history["session_id"].nunique())
+    if history["language"].dropna().nunique() > 1:
+        st.info(history_copy["mixed_languages"])
+    if history["scoring_model_version"].dropna().nunique() > 1:
+        st.warning(history_copy["mixed_versions"])
     st.markdown(f"### {history_copy['latest']}")
     st.markdown(
         metric_grid_html(
@@ -986,6 +1012,8 @@ if primary_view == "trends":
     feature_history = feature_history.copy()
     feature_history["session_label"] = (
         feature_history["session_date"].astype(str)
+        + " · "
+        + feature_history["language"].fillna("Unknown").astype(str)
         + " #"
         + feature_history["session_number"].astype(str)
     )

--- a/aoi_kinabot_app/database.py
+++ b/aoi_kinabot_app/database.py
@@ -386,16 +386,11 @@ def save_feature_scores(test_session_id: int, scores: Iterable[dict]) -> None:
         )
 
 
-def get_user_scores(
-    user_id: int, scoring_model_version: str | None = None
-) -> list[sqlite3.Row]:
-    version_clause = " AND ts.scoring_model_version = ?" if scoring_model_version else ""
-    parameters: tuple = (
-        (user_id, scoring_model_version) if scoring_model_version else (user_id,)
-    )
+def get_user_scores(user_id: int) -> list[sqlite3.Row]:
+    """Return every score stored for one account across languages and versions."""
     with get_connection() as conn:
         return conn.execute(
-            f"""
+            """
             SELECT
                 ts.id AS session_id,
                 ts.created_at,
@@ -411,10 +406,10 @@ def get_user_scores(
                 fs.score
             FROM feature_scores fs
             JOIN test_sessions ts ON ts.id = fs.test_session_id
-            WHERE ts.user_id = ?{version_clause}
+            WHERE ts.user_id = ?
             ORDER BY ts.created_at ASC, fs.feature_name ASC
             """,
-            parameters,
+            (user_id,),
         ).fetchall()
 
 

--- a/aoi_kinabot_app/test_scoring_version_history.py
+++ b/aoi_kinabot_app/test_scoring_version_history.py
@@ -1,7 +1,9 @@
 import database
 
 
-def _save_session(user_id: int, version: str, score: float) -> None:
+def _save_session(
+    user_id: int, version: str, score: float, language: str
+) -> None:
     session_id = database.create_test_session(
         user_id=user_id,
         session_date="2026-08-24",
@@ -9,6 +11,7 @@ def _save_session(user_id: int, version: str, score: float) -> None:
         app_version="test",
         consent_version="test",
         scoring_model_version=version,
+        language=language,
     )
     database.save_feature_scores(
         session_id,
@@ -23,18 +26,22 @@ def _save_session(user_id: int, version: str, score: float) -> None:
     )
 
 
-def test_score_history_can_be_limited_to_one_model_version(tmp_path, monkeypatch):
+def test_score_history_combines_languages_and_model_versions_for_one_user(
+    tmp_path, monkeypatch
+):
     monkeypatch.setattr(database, "DATABASE_PATH", tmp_path / "kina.sqlite3")
     database.init_db()
     user_id = database.upsert_user("version-test")
-    _save_session(user_id, "score-v2-multilingual", 24.0)
-    _save_session(user_id, "score-v3-connector-boundaries", 14.0)
+    assert database.upsert_user("version-test") == user_id
+    _save_session(user_id, "score-v2-multilingual", 24.0, "English")
+    _save_session(user_id, "score-v3-connector-boundaries", 14.0, "中文")
 
-    current_rows = database.get_user_scores(
-        user_id, scoring_model_version="score-v3-connector-boundaries"
-    )
+    rows = database.get_user_scores(user_id)
 
-    assert len(current_rows) == 1
-    assert current_rows[0]["score"] == 14.0
-    assert current_rows[0]["scoring_model_version"] == "score-v3-connector-boundaries"
-    assert len(database.get_user_scores(user_id)) == 2
+    assert len(rows) == 2
+    assert {row["score"] for row in rows} == {14.0, 24.0}
+    assert {row["language"] for row in rows} == {"English", "中文"}
+    assert {row["scoring_model_version"] for row in rows} == {
+        "score-v2-multilingual",
+        "score-v3-connector-boundaries",
+    }


### PR DESCRIPTION
## Summary
- return every saved score for the same verified account across English, Japanese, and Chinese sessions
- keep earlier scoring-model versions visible instead of silently filtering them out
- label chart sessions with their recording language
- show localized cautions when comparing multiple languages or scoring-model versions
- add regression coverage for one account spanning languages and scoring versions

## Validation
- Python compileall passed
- 35 core application tests passed
- git diff --check passed
- API-only test collection requires the repository CI FastAPI environment