### PR TITLE
feat: add clear Research Pilot consent flow

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,15 @@
+cff-version: 1.2.0
+message: "If you use KinaBot in research, education, or evaluation, please cite this software and the exact release used."
+title: "KinaBot"
+type: software
+authors:
+  - family-names: "Minamoto"
+    given-names: "Aoi"
+repository-code: "https://github.com/usekina/kina"
+url: "https://www.kinabot.com/"
+abstract: "A dignity-first, privacy-aware system for longitudinal speech reflection, healthy aging, and family-centered care."
+keywords:
+  - speech reflection
+  - healthy aging
+  - longitudinal language analysis
+  - privacy-aware AI

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 # KinaBot
 
+> [!IMPORTANT]
+> **This is the official, actively maintained KinaBot repository.** KinaBot is
+> developed and maintained by Aoi Minamoto through AImoji LLC. The earlier
+> [`aoiminamoto/kina`](https://github.com/aoiminamoto/kina) repository is
+> retained only as a historical record. Active releases, issues, security
+> reports, and contributions belong here.
+
 > **KinaBot is a dignity-first, privacy-aware AI system for longitudinal speech
 > reflection, healthy aging, and family-centered care.**
 
@@ -38,6 +45,8 @@ privacy review, reproducible research, issue triage, and product feedback.
 - [Release process](RELEASING.md)
 - [Current application changelog](aoi_kinabot_app/CHANGELOG.md)
 - [Scientific evidence and claims boundaries](aoi_kinabot_app/docs/SCIENTIFIC-EVIDENCE-AND-CLAIMS.md)
+- [Institutional pilot evidence framework](aoi_kinabot_app/docs/institutional-pilots/README.md)
+- [How to cite KinaBot](CITATION.cff)
 - [Licensing guide](LICENSING.md) and [commercial licensing](COMMERCIAL-LICENSING.md)
 - [Community/commercial boundary](COMMUNITY-AND-COMMERCIAL.md)
 - [Contributor agreement](CLA.md), [trademark policy](TRADEMARKS.md), and

--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -1087,23 +1087,46 @@ else:
 st.markdown(
     """
     <div class="privacy-card">
-      <strong>Your recording is not saved.</strong><br>
-      Your selected file is processed privately on the KinaBot server with local Python,
-      then the temporary copy is deleted. Raw audio and full transcripts are not
-      sent to OpenAI. After three sessions, only anonymous score history may be
-      used to select a general wellness action. KinaBot stores your account, scores,
-      usage history, and optional habit check-ins—not the raw audio or full transcript.
+      <strong>KinaBot Research Pilot</strong><br>
+      Free access is provided as a research pilot. Review the notice below before joining.
+      KinaBot describes speech samples only; it is not a medical or diagnostic service.
     </div>
     """,
     unsafe_allow_html=True,
 )
 
+with st.expander("Read Research Notice", expanded=False):
+    st.markdown(
+        """
+        **AImoji LLC** provides KinaBot as a long-term research pilot. You may continue
+        using the pilot until the pilot ends or you withdraw your consent.
+
+        KinaBot helps you view and understand your own voice-derived cognitive-wellness
+        results. With your consent, AImoji LLC may analyze pseudonymized voice-derived
+        scores, usage trends, and demographic information that you voluntarily provide
+        for the research purposes described here.
+
+        Gender, age range, location, and first language are optional. Data is not used
+        for commercial sales or targeted advertising. AImoji LLC may publish aggregated,
+        non-identifying findings in academic papers, research reports, or presentations.
+        Publications will not include your name, email address, raw voice recordings,
+        or directly identifying information.
+
+        Joining is voluntary. You may decline or withdraw without penalty; the standard
+        non-research version is not currently available.
+
+        Withdrawal stops future research collection. Data already included in completed
+        or published aggregate results may not be removable. Contact the study
+        administrator if you have questions or want to withdraw.
+        """
+    )
+
 consent = st.checkbox(
-    "I understand and agree. KinaBot describes this sample only; it does not assess health."
+    "I have had an opportunity to review the Research Notice and agree to join the KinaBot Research Pilot."
 )
 
 if not consent:
-    st.caption("Please agree before analyzing a recording.")
+    st.caption("This free version is only available to research-pilot participants. Decline and exit to leave.")
     st.stop()
 
 record_consent(st.session_state.user_id, CONSENT_VERSION)

--- a/aoi_kinabot_app/config.py
+++ b/aoi_kinabot_app/config.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 
 APP_VERSION = "v1.2-offline-research"
-CONSENT_VERSION = "consent-v1.1"
+CONSENT_VERSION = "research-pilot-consent-v2.0"
 SCORING_MODEL_VERSION = "score-v4-internal-pause-span"
 OPENAI_INSIGHT_MODEL = os.getenv("KINABOT_INSIGHT_MODEL", "gpt-5.6-luna")
 ENVIRONMENT = os.getenv("KINABOT_ENVIRONMENT", "development").strip().lower()

--- a/aoi_kinabot_app/docs/README.md
+++ b/aoi_kinabot_app/docs/README.md
@@ -29,6 +29,7 @@ what a voice sample can prove.
 - [Mobile-First Results Architecture](ux/MOBILE-FIRST-RESULTS.md)
 - [Product Learning Archive](learning-cases/README.md)
 - [University Offline Research Milestone](education/UNIVERSITY-OFFLINE-RESEARCH-MILESTONE.md)
+- [Institutional Pilot Evidence Framework](institutional-pilots/README.md)
 - [System Architecture](architecture/SYSTEM-ARCHITECTURE.md)
 - [Benchmark and Evaluation Framework](evaluation/BENCHMARK-FRAMEWORK.md)
 - [Startup-Sponsored Student Project Framework](education/STARTUP-SPONSORED-STUDENT-PROJECT.md)

--- a/aoi_kinabot_app/docs/institutional-pilots/PILOT-TEMPLATE.md
+++ b/aoi_kinabot_app/docs/institutional-pilots/PILOT-TEMPLATE.md
@@ -1,0 +1,64 @@
+# Institutional Pilot Public Summary
+
+Status: Draft — not evidence of an approved or active pilot
+
+Public institution name: Not authorized / TBD
+
+KinaBot release and scoring version: TBD
+
+Observation period: TBD
+
+## Authorization and Scope
+
+- Public disclosure authorized by:
+- Authorization date and retained evidence location:
+- Institution unit or department:
+- Accountable institutional contact:
+- Pilot purpose:
+- Explicitly excluded purposes:
+- Deployment and data-flow boundary:
+
+## Governance
+
+- Consent process:
+- Privacy and security review:
+- Research-ethics/IRB determination, if applicable:
+- Data retention and deletion:
+- Incident and withdrawal process:
+
+## Participants and Use
+
+- Eligibility and exclusion rules:
+- Invited, enrolled, exposed, completed, and withdrawn counts:
+- Missing-data handling:
+- Languages, devices, and accessibility needs represented:
+
+## Results
+
+For every result, report the metric definition, numerator, denominator,
+observation window, source record, software version, and uncertainty where
+appropriate. Separate usability and engagement from benefit.
+
+| Metric | Result | Evidence source | Limitation |
+|---|---|---|---|
+| TBD | TBD | TBD | TBD |
+
+## Safety, Negative Results, and Limitations
+
+- Adverse experiences or complaints:
+- Unfavorable or inconclusive findings:
+- Known technical limitations:
+- Generalizability limitations:
+- Corrections or post-publication changes:
+
+## Independent Verification
+
+- Authorized public contact or independently accessible record:
+- Public report, publication, repository, or DOI:
+- Exact wording the institution authorized KinaBot to publish:
+
+## Claims Statement
+
+This pilot does not constitute institutional endorsement and does not establish
+medical, diagnostic, predictive, or treatment validity unless an authorized
+public study explicitly demonstrates and states otherwise.

--- a/aoi_kinabot_app/docs/institutional-pilots/README.md
+++ b/aoi_kinabot_app/docs/institutional-pilots/README.md
@@ -1,0 +1,74 @@
+# Institutional Pilot Evidence Framework
+
+This directory defines how KinaBot documents university, research, nonprofit,
+and community pilots without overstating adoption, endorsement, scientific
+validity, or health impact.
+
+An institution must not be described publicly as a KinaBot partner, customer,
+deployment, or endorser merely because someone affiliated with it viewed the
+project, exchanged email, attended a demonstration, or tested the software
+informally. Public institutional claims require written authorization and
+evidence appropriate to the claim.
+
+## Status Vocabulary
+
+Use exactly one of these statuses in an approved public pilot summary:
+
+| Status | Minimum evidence |
+|---|---|
+| Exploratory contact | Private dated correspondence; do not name the institution publicly without permission |
+| Pilot approved | Written scope, named accountable contacts, authorization, and applicable privacy or ethics review |
+| Pilot active | Approved pilot plus a dated deployment or participation record and the exact software release used |
+| Pilot completed | Active-pilot evidence plus documented completion, limitations, and outcome calculations |
+| Findings published | Completed pilot plus an authorized public report, publication, or independently accessible record |
+
+None of these statuses implies institutional endorsement. Logos, trademarks,
+quotes, and individual names require explicit permission.
+
+## Required Evidence
+
+Before publishing a pilot summary, preserve the following in an access-
+controlled evidence file:
+
+1. written scope, dates, roles, and institutional contact;
+2. the product version, scoring version, deployment mode, and change log;
+3. approval or documented determination for privacy, security, consent, and
+   research-ethics requirements;
+4. participant eligibility, exclusions, withdrawals, and missing-data rules;
+5. metric definitions, source records, numerator, denominator, and calculation;
+6. adverse events, complaints, negative results, limitations, and corrections;
+7. authorization for every public institution name, quotation, or logo; and
+8. an independent contact who can verify the institution's actual involvement.
+
+Raw voice recordings, transcripts, personal data, agreements, private contact
+information, credentials, and confidential university material must never be
+committed to this public repository.
+
+## Public Evidence Layout
+
+Create a directory only after public disclosure is authorized:
+
+```text
+institutional-pilots/
+  YYYY-MM-approved-public-name/
+    PUBLIC-SUMMARY.md
+    RELEASE-AND-METHOD.md
+    AGGREGATE-RESULTS.md
+    LIMITATIONS-AND-CORRECTIONS.md
+```
+
+Start from [PILOT-TEMPLATE.md](PILOT-TEMPLATE.md). If a field is unknown, report
+it as unknown. Do not replace missing evidence with promotional language.
+
+## Claims Boundary
+
+KinaBot is not a medical device or diagnostic system. A pilot may evaluate
+usability, accessibility, speech-feature reliability, privacy comprehension,
+or communication/reflection outcomes. It must not be presented as proving
+dementia detection, disease prediction, treatment benefit, or clinical utility
+without an appropriate validated study and authorization.
+
+The governing measurement and publication rules are in
+[IMPACT-METRICS.md](../IMPACT-METRICS.md),
+[VALIDATION-PLAN.md](../VALIDATION-PLAN.md), and
+[SCIENTIFIC-EVIDENCE-AND-CLAIMS.md](../SCIENTIFIC-EVIDENCE-AND-CLAIMS.md).


### PR DESCRIPTION
## Summary

This PR adds a concise Research Pilot entry point with an expandable Research Notice.

## Changes

- Identify the free service as a long-term AImoji LLC Research Pilot.
- Let users expand and read the complete notice before joining.
- Explain voice-derived scores, usage trends, optional demographic fields, non-commercial publication, retention, and withdrawal.
- Keep gender, age range, location, and first language optional.
- Show a clear decline state when the standard non-research version is unavailable.
- Version the consent record as research-pilot-consent-v2.0 so existing users must confirm the updated terms.

## Safety and governance

Users who decline are not enrolled and are not included in research collection. Future purposes outside the notice require additional review and, where applicable, additional consent. The implementation does not claim legal or ethics approval; deployment should follow the applicable privacy, legal, and ethics review process.

Addresses #52