### PR TITLE
fix: isolate trends by compatible measurement provenance

### DIFF
--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -39,7 +39,11 @@ from database import (
     upsert_user,
 )
 from email_delivery import send_verification_email
-from history_view import latest_session_scores, metric_grid_html
+from history_view import (
+    latest_session_scores,
+    metric_grid_html,
+    select_latest_comparable_history,
+)
 from insight_service import generate_wellness_insight
 from language_analysis import LANGUAGE_CODES, analyze_transcript
 from local_time import local_date_iso
@@ -985,11 +989,21 @@ if primary_view == "trends":
             use_container_width=True,
         )
 
-    if session_count < 3:
-        st.info(history_copy["progress"].format(count=session_count))
+    comparable_history, comparison_key = select_latest_comparable_history(history)
+    comparable_count = int(comparable_history["session_id"].nunique())
+    if comparison_key is None:
+        st.info(
+            "Not enough comparable sessions for a trend yet. Complete 3 sessions "
+            "using the same spoken language and analysis version."
+        )
         st.stop()
+    st.caption(
+        "Comparison set: "
+        f"{comparison_key[0]} · scoring {comparison_key[1]} · pipeline {comparison_key[2]} "
+        f"({comparable_count} sessions). Other history is preserved but not compared."
+    )
 
-    feature_names = list(history["feature_name"].drop_duplicates())
+    feature_names = list(comparable_history["feature_name"].drop_duplicates())
     selected_feature = st.selectbox(
         history_copy["recent"],
         feature_names,
@@ -1004,9 +1018,9 @@ if primary_view == "trends":
         horizontal=True,
         label_visibility="collapsed",
     )
-    feature_history = history[history["feature_name"] == selected_feature].sort_values(
-        "session_id"
-    )
+    feature_history = comparable_history[
+        comparable_history["feature_name"] == selected_feature
+    ].sort_values("session_id")
     if history_scope == "recent":
         feature_history = feature_history.tail(3)
     feature_history = feature_history.copy()
@@ -1027,7 +1041,7 @@ if primary_view == "trends":
     )
     st.line_chart(chart_df, height=260)
 
-    ordered = history.sort_values("session_id")
+    ordered = comparable_history.sort_values("session_id")
     first_score = float(
         ordered[ordered["feature_name"] == selected_feature].iloc[0]["score"]
     )
@@ -1046,7 +1060,9 @@ if primary_view == "trends":
     st.write(f"{pattern} ({observed_change:+.1f})")
     st.caption(history_copy["boundary"])
 
-    insight = generate_wellness_insight([dict(row) for row in rows], st.session_state.ui_language)
+    insight = generate_wellness_insight(
+        comparable_history.to_dict("records"), st.session_state.ui_language
+    )
     st.markdown("#### One small action")
     if insight.get("encouragement"):
         st.write(insight["encouragement"])

--- a/aoi_kinabot_app/history_view.py
+++ b/aoi_kinabot_app/history_view.py
@@ -9,6 +9,46 @@ import pandas as pd
 from scoring import display_feature_name
 
 
+COMPARISON_KEY_COLUMNS = ("language", "scoring_model_version", "app_version")
+
+
+def comparison_key(row: dict) -> tuple[str, ...]:
+    """Return the provenance key that makes two sessions comparable."""
+    return tuple(str(row.get(column) or "unknown") for column in COMPARISON_KEY_COLUMNS)
+
+
+def select_latest_comparable_history(
+    history: pd.DataFrame, minimum_sessions: int = 3
+) -> tuple[pd.DataFrame, tuple[str, ...] | None]:
+    """Select the newest compatible group without dropping historical records."""
+    if history.empty:
+        return history.copy(), None
+    working = history.copy()
+    working["_comparison_key"] = working.apply(
+        lambda row: comparison_key(row.to_dict()), axis=1
+    )
+    counts = (
+        working[["_comparison_key", "session_id"]]
+        .drop_duplicates()
+        .groupby("_comparison_key")["session_id"]
+        .nunique()
+    )
+    eligible = set(counts[counts >= minimum_sessions].index)
+    if not eligible:
+        return working.drop(columns=["_comparison_key"]), None
+    latest = (
+        working[working["_comparison_key"].isin(eligible)]
+        .groupby("_comparison_key")["session_id"]
+        .max()
+        .sort_values()
+    )
+    selected = latest.index[-1]
+    result = working[working["_comparison_key"] == selected].drop(
+        columns=["_comparison_key"]
+    )
+    return result, selected
+
+
 def metric_grid_html(score_items: list[dict], language: str) -> str:
     """Return a compact two-column score grid suitable for narrow screens."""
     tiles = []

--- a/aoi_kinabot_app/test_history_comparability.py
+++ b/aoi_kinabot_app/test_history_comparability.py
@@ -1,0 +1,36 @@
+import pandas as pd
+
+from history_view import select_latest_comparable_history
+
+
+def _rows():
+    rows = []
+    session_id = 1
+    for language, count in [("English", 3), ("日本語", 3)]:
+        for _ in range(count):
+            rows.append(
+                {
+                    "session_id": session_id,
+                    "language": language,
+                    "scoring_model_version": "score-v4",
+                    "app_version": "v1.2",
+                    "feature_name": "Pause Ratio",
+                    "score": float(session_id),
+                }
+            )
+            session_id += 1
+    return pd.DataFrame(rows)
+
+
+def test_selects_newest_eligible_group_and_keeps_only_its_rows():
+    selected, key = select_latest_comparable_history(_rows())
+    assert key == ("日本語", "score-v4", "v1.2")
+    assert selected["language"].nunique() == 1
+    assert selected["session_id"].nunique() == 3
+
+
+def test_fewer_than_three_sessions_is_not_comparable():
+    frame = _rows().iloc[:2].copy()
+    selected, key = select_latest_comparable_history(frame)
+    assert key is None
+    assert len(selected) == len(frame)


### PR DESCRIPTION
## Summary

Fixes #50 by separating historical visibility from comparable trend calculations.

## Changes

- Preserve all historical sessions for the user.
- Select the newest comparison group with at least three sessions.
- Group by spoken language, scoring model version, and app/pipeline version.
- Restrict charts, deltas, Higher/Lower/Similar labels, and wellness insights to that group.
- Show the selected comparison set and explain that other history is preserved but not compared.
- Show an insufficient-comparable-sessions message instead of calculating a mixed trend.
- Add regression tests for mixed-language groups and insufficient history.

## Verification

- pytest -q test_history_comparability.py test_scoring_version_history.py (3 passed)
- Python syntax compilation passed.

Historical records are not deleted, and incompatible records are not silently merged.