### PR TITLE
feat: add participant data management controls

### DIFF
--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date
+import json
 import uuid
 import pandas as pd
 import streamlit as st
@@ -31,6 +32,9 @@ from database import (
     get_user_habit_checkins,
     get_user_profile,
     get_user_scores,
+    has_active_consent,
+    delete_user_research_data,
+    export_user_data,
     init_db,
     list_admin_test_records,
     list_admin_users,
@@ -39,6 +43,7 @@ from database import (
     save_feature_scores,
     save_habit_checkins,
     update_user_profile,
+    withdraw_research_consent,
     upsert_user,
 )
 from email_delivery import send_verification_email
@@ -876,12 +881,9 @@ language_options = [
 if saved_name:
     st.markdown(f"### Welcome back, {saved_name}")
 
-profile_complete = bool(
-    saved_name and profile.get("age_range") and profile.get("gender")
-)
 with st.expander(
-    "Account settings" if profile_complete else "Complete your account",
-    expanded=not profile_complete,
+    "Account settings",
+    expanded=False,
 ):
     st.caption(st.session_state.email)
     display_name = st.text_input(
@@ -924,25 +926,45 @@ with st.expander(
         placeholder="Example: US",
     )
     if st.button("Save account"):
-        if not display_name.strip() or age_range is None or gender is None:
-            st.error("Please enter your name and select age range and gender.")
-        else:
-            update_user_profile(
-                st.session_state.user_id,
-                display_name.strip(),
-                age_range,
-                gender,
-                None if primary_language == "Prefer not to say" else primary_language,
-                country_region.strip() or None,
-            )
-            refreshed_profile = get_user_profile(st.session_state.user_id)
-            st.session_state.profile = dict(refreshed_profile) if refreshed_profile else {}
-            st.success("Account saved.")
-            st.rerun()
+        update_user_profile(
+            st.session_state.user_id,
+            display_name.strip() or None,
+            None if age_range in (None, "Prefer not to say") else age_range,
+            None if gender in (None, "Prefer not to say") else gender,
+            None if primary_language == "Prefer not to say" else primary_language,
+            country_region.strip() or None,
+        )
+        refreshed_profile = get_user_profile(st.session_state.user_id)
+        st.session_state.profile = dict(refreshed_profile) if refreshed_profile else {}
+        st.success("Account saved.")
+        st.rerun()
 
-if not profile_complete:
-    st.info("Complete your account once. KinaBot will remember it for future visits.")
-    st.stop()
+with st.expander("Manage my data"):
+    st.caption("View, export, correct, withdraw, or delete your KinaBot data.")
+    export_payload = export_user_data(st.session_state.user_id)
+    st.download_button(
+        "Download my data",
+        data=json.dumps(export_payload, ensure_ascii=False, indent=2).encode("utf-8"),
+        file_name="kinabot_my_data.json",
+        mime="application/json",
+        use_container_width=True,
+    )
+    if st.button("Withdraw from research"):
+        withdraw_research_consent(st.session_state.user_id)
+        st.session_state["research_pilot_consent"] = False
+        st.warning("Future research collection is stopped. You must re-consent to rejoin.")
+        st.stop()
+    if st.button("Log out"):
+        st.session_state.clear()
+        st.rerun()
+    st.divider()
+    st.caption("Account deletion permanently removes your profile, sessions, scores, habits, consent records, and verification records.")
+    delete_confirm = st.checkbox("I understand this cannot be undone.")
+    if st.button("Delete account and history", disabled=not delete_confirm):
+        delete_user_research_data(st.session_state.user_id)
+        st.session_state.clear()
+        st.success("Your account and stored data have been deleted.")
+        st.stop()
 
 history_copy = HISTORY_COPY[st.session_state.ui_language]
 challenge_copy = CHALLENGE_COPY[st.session_state.ui_language]
@@ -1141,7 +1163,9 @@ with st.expander("Read Research Notice", expanded=False):
     )
 
 consent = st.checkbox(
-    "I have had an opportunity to review the Research Notice and agree to join the KinaBot Research Pilot."
+    "I have had an opportunity to review the Research Notice and agree to join the KinaBot Research Pilot.",
+    value=has_active_consent(st.session_state.user_id, CONSENT_VERSION),
+    key="research_pilot_consent",
 )
 
 if not consent:

--- a/aoi_kinabot_app/database.py
+++ b/aoi_kinabot_app/database.py
@@ -61,6 +61,7 @@ def init_db() -> None:
                 user_id INTEGER NOT NULL,
                 consent_version TEXT NOT NULL,
                 accepted_at TEXT NOT NULL,
+                withdrawn_at TEXT,
                 FOREIGN KEY (user_id) REFERENCES users(id)
             );
 
@@ -115,6 +116,7 @@ def init_db() -> None:
         ensure_column(conn, "test_sessions", "language", "TEXT")
         ensure_column(conn, "test_sessions", "duration_seconds", "REAL")
         ensure_column(conn, "test_sessions", "timezone_name", "TEXT")
+        ensure_column(conn, "consent_events", "withdrawn_at", "TEXT")
         ensure_column(conn, "test_sessions", "idempotency_key", "TEXT")
         _repair_legacy_session_number_duplicates(conn)
         conn.execute(
@@ -197,6 +199,10 @@ def delete_user_research_data(user_id: int) -> bool:
                 f"DELETE FROM feature_scores WHERE test_session_id IN ({placeholders})",
                 session_ids,
             )
+        email_hash = conn.execute(
+            "SELECT email_hash FROM users WHERE id = ?", (user_id,)
+        ).fetchone()["email_hash"]
+        conn.execute("DELETE FROM verification_codes WHERE email_hash = ?", (email_hash,))
         conn.execute("DELETE FROM habit_checkins WHERE user_id = ?", (user_id,))
         conn.execute("DELETE FROM consent_events WHERE user_id = ?", (user_id,))
         conn.execute("DELETE FROM test_sessions WHERE user_id = ?", (user_id,))
@@ -254,11 +260,70 @@ def record_consent(user_id: int, consent_version: str) -> None:
             WHERE NOT EXISTS (
                 SELECT 1
                 FROM consent_events
-                WHERE user_id = ? AND consent_version = ?
+                WHERE user_id = ? AND consent_version = ? AND withdrawn_at IS NULL
             )
             """,
             (user_id, consent_version, utc_now_iso(), user_id, consent_version),
         )
+
+
+def has_active_consent(user_id: int, consent_version: str) -> bool:
+    with get_connection() as conn:
+        return bool(conn.execute(
+            "SELECT 1 FROM consent_events WHERE user_id = ? AND consent_version = ? "
+            "AND withdrawn_at IS NULL LIMIT 1", (user_id, consent_version)
+        ).fetchone())
+
+
+def withdraw_research_consent(user_id: int) -> int:
+    """Stop future research use while retaining the consent audit event."""
+    with get_connection() as conn:
+        cursor = conn.execute(
+            "UPDATE consent_events SET withdrawn_at = ? "
+            "WHERE user_id = ? AND withdrawn_at IS NULL",
+            (utc_now_iso(), user_id),
+        )
+        return int(cursor.rowcount)
+
+
+def export_user_data(user_id: int) -> dict:
+    """Return a participant's stored data in a portable JSON-compatible shape."""
+    with get_connection() as conn:
+        user = conn.execute(
+            "SELECT id, email, display_name, age_range, gender, primary_language, "
+            "country_region, timezone_name, created_at, last_active_at "
+            "FROM users WHERE id = ?", (user_id,)
+        ).fetchone()
+        if not user:
+            return {}
+        sessions = conn.execute(
+            "SELECT * FROM test_sessions WHERE user_id = ? ORDER BY created_at ASC, id ASC",
+            (user_id,),
+        ).fetchall()
+        session_ids = [int(row["id"]) for row in sessions]
+        scores = []
+        if session_ids:
+            placeholders = ",".join("?" for _ in session_ids)
+            scores = conn.execute(
+                f"SELECT * FROM feature_scores WHERE test_session_id IN ({placeholders}) "
+                "ORDER BY test_session_id ASC, id ASC", session_ids
+            ).fetchall()
+        consents = conn.execute(
+            "SELECT consent_version, accepted_at, withdrawn_at FROM consent_events "
+            "WHERE user_id = ? ORDER BY accepted_at ASC", (user_id,)
+        ).fetchall()
+        habits = conn.execute(
+            "SELECT checkin_date, habit_name, completed, created_at, updated_at "
+            "FROM habit_checkins WHERE user_id = ? ORDER BY checkin_date ASC, id ASC",
+            (user_id,),
+        ).fetchall()
+        return {
+            "profile": dict(user),
+            "sessions": [dict(row) for row in sessions],
+            "feature_scores": [dict(row) for row in scores],
+            "consent_events": [dict(row) for row in consents],
+            "habit_checkins": [dict(row) for row in habits],
+        }
 
 
 def save_verification_code(email_hash: str, code_hash: str, expires_at: str) -> None:


### PR DESCRIPTION
## Summary

Implements the core participant controls proposed in #53.

## Changes

- Make name, age range, and gender optional; users can continue without demographic fields.
- Add a compact Manage my data area.
- Allow participants to download their stored data as JSON.
- Allow profile correction through Account settings.
- Add consent withdrawal with a recorded withdrawal timestamp.
- Prevent withdrawn consent from being treated as active.
- Add logout that clears Streamlit session state.
- Add account/history deletion with verification through the authenticated session.
- Delete matching verification-code records with the account.
- Add consent-schema migration for withdrawal state.

## Verification

- 19 existing scoring/multilingual tests passed.
- Python syntax compilation passed.

Backup retention and formal legal/ethics policy review remain deployment requirements.