### PR TITLE
Add personal PDF report for Research Pilot

### DIFF
--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date
+import json
 import uuid
 import pandas as pd
 import streamlit as st
@@ -31,6 +32,9 @@ from database import (
     get_user_habit_checkins,
     get_user_profile,
     get_user_scores,
+    has_active_consent,
+    delete_user_research_data,
+    export_user_data,
     init_db,
     list_admin_test_records,
     list_admin_users,
@@ -39,6 +43,7 @@ from database import (
     save_feature_scores,
     save_habit_checkins,
     update_user_profile,
+    withdraw_research_consent,
     upsert_user,
 )
 from email_delivery import send_verification_email
@@ -876,12 +881,9 @@ language_options = [
 if saved_name:
     st.markdown(f"### Welcome back, {saved_name}")
 
-profile_complete = bool(
-    saved_name and profile.get("age_range") and profile.get("gender")
-)
 with st.expander(
-    "Account settings" if profile_complete else "Complete your account",
-    expanded=not profile_complete,
+    "Account settings",
+    expanded=False,
 ):
     st.caption(st.session_state.email)
     display_name = st.text_input(
@@ -924,25 +926,45 @@ with st.expander(
         placeholder="Example: US",
     )
     if st.button("Save account"):
-        if not display_name.strip() or age_range is None or gender is None:
-            st.error("Please enter your name and select age range and gender.")
-        else:
-            update_user_profile(
-                st.session_state.user_id,
-                display_name.strip(),
-                age_range,
-                gender,
-                None if primary_language == "Prefer not to say" else primary_language,
-                country_region.strip() or None,
-            )
-            refreshed_profile = get_user_profile(st.session_state.user_id)
-            st.session_state.profile = dict(refreshed_profile) if refreshed_profile else {}
-            st.success("Account saved.")
-            st.rerun()
+        update_user_profile(
+            st.session_state.user_id,
+            display_name.strip() or None,
+            None if age_range in (None, "Prefer not to say") else age_range,
+            None if gender in (None, "Prefer not to say") else gender,
+            None if primary_language == "Prefer not to say" else primary_language,
+            country_region.strip() or None,
+        )
+        refreshed_profile = get_user_profile(st.session_state.user_id)
+        st.session_state.profile = dict(refreshed_profile) if refreshed_profile else {}
+        st.success("Account saved.")
+        st.rerun()
 
-if not profile_complete:
-    st.info("Complete your account once. KinaBot will remember it for future visits.")
-    st.stop()
+with st.expander("Manage my data"):
+    st.caption("View, export, correct, withdraw, or delete your KinaBot data.")
+    export_payload = export_user_data(st.session_state.user_id)
+    st.download_button(
+        "Download my data",
+        data=json.dumps(export_payload, ensure_ascii=False, indent=2).encode("utf-8"),
+        file_name="kinabot_my_data.json",
+        mime="application/json",
+        use_container_width=True,
+    )
+    if st.button("Withdraw from research"):
+        withdraw_research_consent(st.session_state.user_id)
+        st.session_state["research_pilot_consent"] = False
+        st.warning("Future research collection is stopped. You must re-consent to rejoin.")
+        st.stop()
+    if st.button("Log out"):
+        st.session_state.clear()
+        st.rerun()
+    st.divider()
+    st.caption("Account deletion permanently removes your profile, sessions, scores, habits, consent records, and verification records.")
+    delete_confirm = st.checkbox("I understand this cannot be undone.")
+    if st.button("Delete account and history", disabled=not delete_confirm):
+        delete_user_research_data(st.session_state.user_id)
+        st.session_state.clear()
+        st.success("Your account and stored data have been deleted.")
+        st.stop()
 
 history_copy = HISTORY_COPY[st.session_state.ui_language]
 challenge_copy = CHALLENGE_COPY[st.session_state.ui_language]
@@ -1141,7 +1163,9 @@ with st.expander("Read Research Notice", expanded=False):
     )
 
 consent = st.checkbox(
-    "I have had an opportunity to review the Research Notice and agree to join the KinaBot Research Pilot."
+    "I have had an opportunity to review the Research Notice and agree to join the KinaBot Research Pilot.",
+    value=has_active_consent(st.session_state.user_id, CONSENT_VERSION),
+    key="research_pilot_consent",
 )
 
 if not consent:

--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -56,6 +56,7 @@ from insight_service import generate_wellness_insight
 from language_analysis import LANGUAGE_CODES, analyze_transcript
 from local_time import local_date_iso
 from offline_identity import normalize_participant_id, participant_key, valid_participant_id
+from pilot_report import build_personal_pdf_report
 from speech_to_text import (
     LOCAL_TRANSCRIPTION_TYPES,
     speech_to_text_configured,
@@ -947,6 +948,18 @@ with st.expander("Manage my data"):
         data=json.dumps(export_payload, ensure_ascii=False, indent=2).encode("utf-8"),
         file_name="kinabot_my_data.json",
         mime="application/json",
+        use_container_width=True,
+    )
+    personal_report = build_personal_pdf_report(
+        st.session_state.get("profile") or {},
+        get_user_scores(st.session_state.user_id),
+    )
+    st.download_button(
+        "Download my PDF report",
+        data=personal_report,
+        file_name="kinabot_research_pilot_report.pdf",
+        mime="application/pdf",
+        help="A basic report of your own scores. It excludes raw audio and internal model data.",
         use_container_width=True,
     )
     if st.button("Withdraw from research"):

--- a/aoi_kinabot_app/database.py
+++ b/aoi_kinabot_app/database.py
@@ -61,6 +61,7 @@ def init_db() -> None:
                 user_id INTEGER NOT NULL,
                 consent_version TEXT NOT NULL,
                 accepted_at TEXT NOT NULL,
+                withdrawn_at TEXT,
                 FOREIGN KEY (user_id) REFERENCES users(id)
             );
 
@@ -115,6 +116,7 @@ def init_db() -> None:
         ensure_column(conn, "test_sessions", "language", "TEXT")
         ensure_column(conn, "test_sessions", "duration_seconds", "REAL")
         ensure_column(conn, "test_sessions", "timezone_name", "TEXT")
+        ensure_column(conn, "consent_events", "withdrawn_at", "TEXT")
         ensure_column(conn, "test_sessions", "idempotency_key", "TEXT")
         _repair_legacy_session_number_duplicates(conn)
         conn.execute(
@@ -197,6 +199,10 @@ def delete_user_research_data(user_id: int) -> bool:
                 f"DELETE FROM feature_scores WHERE test_session_id IN ({placeholders})",
                 session_ids,
             )
+        email_hash = conn.execute(
+            "SELECT email_hash FROM users WHERE id = ?", (user_id,)
+        ).fetchone()["email_hash"]
+        conn.execute("DELETE FROM verification_codes WHERE email_hash = ?", (email_hash,))
         conn.execute("DELETE FROM habit_checkins WHERE user_id = ?", (user_id,))
         conn.execute("DELETE FROM consent_events WHERE user_id = ?", (user_id,))
         conn.execute("DELETE FROM test_sessions WHERE user_id = ?", (user_id,))
@@ -254,11 +260,70 @@ def record_consent(user_id: int, consent_version: str) -> None:
             WHERE NOT EXISTS (
                 SELECT 1
                 FROM consent_events
-                WHERE user_id = ? AND consent_version = ?
+                WHERE user_id = ? AND consent_version = ? AND withdrawn_at IS NULL
             )
             """,
             (user_id, consent_version, utc_now_iso(), user_id, consent_version),
         )
+
+
+def has_active_consent(user_id: int, consent_version: str) -> bool:
+    with get_connection() as conn:
+        return bool(conn.execute(
+            "SELECT 1 FROM consent_events WHERE user_id = ? AND consent_version = ? "
+            "AND withdrawn_at IS NULL LIMIT 1", (user_id, consent_version)
+        ).fetchone())
+
+
+def withdraw_research_consent(user_id: int) -> int:
+    """Stop future research use while retaining the consent audit event."""
+    with get_connection() as conn:
+        cursor = conn.execute(
+            "UPDATE consent_events SET withdrawn_at = ? "
+            "WHERE user_id = ? AND withdrawn_at IS NULL",
+            (utc_now_iso(), user_id),
+        )
+        return int(cursor.rowcount)
+
+
+def export_user_data(user_id: int) -> dict:
+    """Return a participant's stored data in a portable JSON-compatible shape."""
+    with get_connection() as conn:
+        user = conn.execute(
+            "SELECT id, email, display_name, age_range, gender, primary_language, "
+            "country_region, timezone_name, created_at, last_active_at "
+            "FROM users WHERE id = ?", (user_id,)
+        ).fetchone()
+        if not user:
+            return {}
+        sessions = conn.execute(
+            "SELECT * FROM test_sessions WHERE user_id = ? ORDER BY created_at ASC, id ASC",
+            (user_id,),
+        ).fetchall()
+        session_ids = [int(row["id"]) for row in sessions]
+        scores = []
+        if session_ids:
+            placeholders = ",".join("?" for _ in session_ids)
+            scores = conn.execute(
+                f"SELECT * FROM feature_scores WHERE test_session_id IN ({placeholders}) "
+                "ORDER BY test_session_id ASC, id ASC", session_ids
+            ).fetchall()
+        consents = conn.execute(
+            "SELECT consent_version, accepted_at, withdrawn_at FROM consent_events "
+            "WHERE user_id = ? ORDER BY accepted_at ASC", (user_id,)
+        ).fetchall()
+        habits = conn.execute(
+            "SELECT checkin_date, habit_name, completed, created_at, updated_at "
+            "FROM habit_checkins WHERE user_id = ? ORDER BY checkin_date ASC, id ASC",
+            (user_id,),
+        ).fetchall()
+        return {
+            "profile": dict(user),
+            "sessions": [dict(row) for row in sessions],
+            "feature_scores": [dict(row) for row in scores],
+            "consent_events": [dict(row) for row in consents],
+            "habit_checkins": [dict(row) for row in habits],
+        }
 
 
 def save_verification_code(email_hash: str, code_hash: str, expires_at: str) -> None:

--- a/aoi_kinabot_app/pilot_report.py
+++ b/aoi_kinabot_app/pilot_report.py
@@ -1,0 +1,114 @@
+"""Generate a small, privacy-conscious PDF for a participant's own results."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from io import BytesIO
+from typing import Iterable, Mapping
+
+
+def build_personal_pdf_report(
+    profile: Mapping[str, object] | None,
+    score_rows: Iterable[Mapping[str, object]],
+) -> bytes:
+    """Return a basic PDF containing only the participant's own summary.
+
+    The report intentionally excludes raw audio, prompts, model internals,
+    administrator fields, and other participants' data.
+    """
+    try:
+        from reportlab.lib import colors
+        from reportlab.lib.pagesizes import letter
+        from reportlab.lib.styles import getSampleStyleSheet
+        from reportlab.lib.units import inch
+        from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+    except ImportError as exc:  # pragma: no cover - exercised in deployment checks
+        raise RuntimeError("PDF reports require the 'reportlab' package") from exc
+
+    rows = [dict(row) for row in score_rows]
+    latest_session = rows[-1].get("session_id") if rows else None
+    latest = [row for row in rows if row.get("session_id") == latest_session]
+    buffer = BytesIO()
+    document = SimpleDocTemplate(
+        buffer,
+        pagesize=letter,
+        rightMargin=0.55 * inch,
+        leftMargin=0.55 * inch,
+        topMargin=0.55 * inch,
+        bottomMargin=0.55 * inch,
+        title="KinaBot Research Pilot Report",
+        author="AImoji LLC",
+    )
+    styles = getSampleStyleSheet()
+    story = [
+        Paragraph("KinaBot Research Pilot Report", styles["Title"]),
+        Paragraph(
+            "Personal informational report · Not a medical or diagnostic report",
+            styles["Normal"],
+        ),
+        Spacer(1, 10),
+    ]
+    display_name = str((profile or {}).get("display_name") or "Participant")
+    story.append(Paragraph(f"Participant: {display_name}", styles["Normal"]))
+    story.append(
+        Paragraph(
+            "Generated: "
+            + datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+            styles["Normal"],
+        )
+    )
+    if not latest:
+        story.append(Spacer(1, 12))
+        story.append(Paragraph("No completed score session is available yet.", styles["Normal"]))
+    else:
+        session = latest[0]
+        story.extend(
+            [
+                Spacer(1, 10),
+                Paragraph(
+                    "Latest session: "
+                    + str(session.get("session_date") or session.get("created_at") or "—"),
+                    styles["Normal"],
+                ),
+                Paragraph("Language: " + str(session.get("language") or "—"), styles["Normal"]),
+                Paragraph(
+                    "Scoring model: " + str(session.get("scoring_model_version") or "—"),
+                    styles["Normal"],
+                ),
+                Spacer(1, 8),
+            ]
+        )
+        table_data = [["Feature", "Score"]]
+        for row in latest:
+            table_data.append([str(row.get("feature_name") or "—"), str(row.get("score") or "—")])
+        table = Table(table_data, colWidths=[4.9 * inch, 1.0 * inch], repeatRows=1)
+        table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#e85d2a")),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                    ("GRID", (0, 0), (-1, -1), 0.35, colors.HexColor("#d9dee8")),
+                    ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, colors.HexColor("#f7f9fc")]),
+                    ("ALIGN", (1, 1), (1, -1), "RIGHT"),
+                    ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("PADDING", (0, 0), (-1, -1), 6),
+                ]
+            )
+        )
+        story.append(table)
+        story.append(Spacer(1, 12))
+        story.append(Paragraph(f"Completed sessions in this account: {len({r.get('session_id') for r in rows})}", styles["Normal"]))
+    story.extend(
+        [
+            Spacer(1, 18),
+            Paragraph(
+                "This report is provided for personal informational and research-pilot purposes only. "
+                "It does not diagnose, treat, or predict any medical condition. Scores are sample "
+                "feature indices and should not be interpreted as clinical measurements.",
+                styles["Italic"],
+            ),
+        ]
+    )
+    document.build(story)
+    return buffer.getvalue()

--- a/aoi_kinabot_app/requirements-offline.txt
+++ b/aoi_kinabot_app/requirements-offline.txt
@@ -9,3 +9,4 @@ fastapi>=0.115.0
 uvicorn[standard]>=0.34.0
 python-multipart>=0.0.20
 httpx>=0.28.0
+reportlab>=4.2,<5

--- a/aoi_kinabot_app/requirements.txt
+++ b/aoi_kinabot_app/requirements.txt
@@ -5,3 +5,4 @@ faster-whisper>=1.1.0
 jieba>=0.42.1
 janome>=0.5.0
 tzdata>=2026.1
+reportlab>=4.2,<5


### PR DESCRIPTION
## Summary\n- Add a participant-facing basic PDF report for the Research Pilot\n- Keep the report limited to the participant's own summary, scores, dates, language, and scoring-model version\n- Exclude raw audio, internal model data, and other participant data\n- Add reportlab to online and offline app dependencies\n\n## Validation\n- Python syntax compilation passed for app.py, pilot_report.py, and database.py\n\nThis PR follows the participant data controls already merged in PR #58.