### PR TITLE
Distinguish unavailable measurements and record pipeline provenance

### DIFF
--- a/aoi_kinabot_app/app.py
+++ b/aoi_kinabot_app/app.py
@@ -15,6 +15,7 @@ from config import (
     ADMIN_KEY,
     ALLOW_LOCAL_VERIFICATION_CODES,
     APP_VERSION,
+    ANALYSIS_PIPELINE_ID,
     CONSENT_VERSION,
     MAX_AUDIO_BYTES,
     MAX_TESTS_PER_DAY,
@@ -998,7 +999,13 @@ if primary_view == "trends":
         st.caption(history_copy["no_scores"])
         st.stop()
 
-    history = pd.DataFrame([dict(row) for row in rows])
+    history = pd.DataFrame([
+        dict(row) for row in rows
+        if row["score"] is not None and row["availability_status"] != "unavailable"
+    ])
+    if history.empty:
+        st.info("No measured features are available for comparable trends yet.")
+        st.stop()
     session_count = int(history["session_id"].nunique())
     if history["language"].dropna().nunique() > 1:
         st.info(history_copy["mixed_languages"])
@@ -1298,6 +1305,7 @@ if st.button("3 · Analyze my reflection", type="primary", use_container_width=T
                     app_version=APP_VERSION,
                     consent_version=CONSENT_VERSION,
                     scoring_model_version=SCORING_MODEL_VERSION,
+                    analysis_pipeline_id=ANALYSIS_PIPELINE_ID,
                     scores=scores,
                     max_tests_per_day=MAX_TESTS_PER_DAY,
                     session_type=session_type,
@@ -1339,22 +1347,27 @@ if st.button("3 · Analyze my reflection", type="primary", use_container_width=T
             },
         }[language]
         st.success(result_copy["saved"])
-        snapshot = build_reflection_profile(scores, language)
+        available_scores = [item for item in scores if item.get("score") is not None]
+        unavailable = [item for item in scores if item.get("score") is None]
+        if unavailable:
+            st.info("Some features were unavailable and were excluded from summaries.")
+        snapshot = build_reflection_profile(available_scores, language)
         st.markdown(f"### {snapshot['title']}")
         st.caption(snapshot["subtitle"])
         snapshot_columns = st.columns(2)
         for index, dimension in enumerate(snapshot["dimensions"]):
-            score = int(dimension["score"])
+            score = dimension["score"]
+            score_label = str(int(score)) if score is not None else "Not available"
             with snapshot_columns[index % 2]:
                 st.markdown(
                     f"""
                     <div class="snapshot-card">
                       <div class="snapshot-card__top">
                         <span class="snapshot-card__label">{dimension["label"]}</span>
-                        <span class="snapshot-card__value">{score}</span>
+                        <span class="snapshot-card__value">{score_label}</span>
                       </div>
                       <div class="snapshot-card__track">
-                        <div class="snapshot-card__fill" style="width:{score}%"></div>
+                        <div class="snapshot-card__fill" style="width:{score or 0}%"></div>
                       </div>
                     </div>
                     """,

--- a/aoi_kinabot_app/config.py
+++ b/aoi_kinabot_app/config.py
@@ -6,6 +6,10 @@ from pathlib import Path
 APP_VERSION = "v1.2-offline-research"
 CONSENT_VERSION = "research-pilot-consent-v2.0"
 SCORING_MODEL_VERSION = "score-v4-internal-pause-span"
+ANALYSIS_PIPELINE_ID = (
+    f"pipeline-v1|app={APP_VERSION}|score={SCORING_MODEL_VERSION}|"
+    f"stt={os.getenv('KINABOT_STT_PIPELINE', 'whisper-configured')}"
+)
 OPENAI_INSIGHT_MODEL = os.getenv("KINABOT_INSIGHT_MODEL", "gpt-5.6-luna")
 ENVIRONMENT = os.getenv("KINABOT_ENVIRONMENT", "development").strip().lower()
 OFFLINE_RESEARCH_MODE = (

--- a/aoi_kinabot_app/database.py
+++ b/aoi_kinabot_app/database.py
@@ -77,6 +77,7 @@ def init_db() -> None:
                 app_version TEXT NOT NULL,
                 consent_version TEXT NOT NULL,
                 scoring_model_version TEXT NOT NULL,
+                analysis_pipeline_id TEXT NOT NULL DEFAULT 'legacy-unknown',
                 created_at TEXT NOT NULL,
                 FOREIGN KEY (user_id) REFERENCES users(id)
             );
@@ -86,7 +87,9 @@ def init_db() -> None:
                 test_session_id INTEGER NOT NULL,
                 feature_name TEXT NOT NULL,
                 raw_metric TEXT,
-                score REAL NOT NULL,
+                score REAL,
+                availability_status TEXT NOT NULL DEFAULT 'available',
+                failure_reason TEXT,
                 explanation TEXT NOT NULL,
                 created_at TEXT NOT NULL,
                 FOREIGN KEY (test_session_id) REFERENCES test_sessions(id)
@@ -118,6 +121,10 @@ def init_db() -> None:
         ensure_column(conn, "test_sessions", "timezone_name", "TEXT")
         ensure_column(conn, "consent_events", "withdrawn_at", "TEXT")
         ensure_column(conn, "test_sessions", "idempotency_key", "TEXT")
+        ensure_column(conn, "test_sessions", "analysis_pipeline_id", "TEXT NOT NULL DEFAULT 'legacy-unknown'")
+        ensure_column(conn, "feature_scores", "availability_status", "TEXT NOT NULL DEFAULT 'available'")
+        ensure_column(conn, "feature_scores", "failure_reason", "TEXT")
+        _migrate_feature_scores_nullable(conn)
         _repair_legacy_session_number_duplicates(conn)
         conn.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS ux_sessions_user_date_number "
@@ -131,6 +138,38 @@ def init_db() -> None:
             "CREATE UNIQUE INDEX IF NOT EXISTS ux_sessions_idempotency_key "
             "ON test_sessions(idempotency_key) WHERE idempotency_key IS NOT NULL"
         )
+
+
+def _migrate_feature_scores_nullable(conn: sqlite3.Connection) -> None:
+    """Rebuild legacy tables whose score column was declared NOT NULL."""
+    info = next((row for row in conn.execute("PRAGMA table_info(feature_scores)") if row[1] == "score"), None)
+    if not info or not info[3]:
+        return
+    conn.execute("ALTER TABLE feature_scores RENAME TO feature_scores_legacy")
+    conn.execute(
+        """CREATE TABLE feature_scores (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            test_session_id INTEGER NOT NULL,
+            feature_name TEXT NOT NULL,
+            raw_metric TEXT,
+            score REAL,
+            availability_status TEXT NOT NULL DEFAULT 'available',
+            failure_reason TEXT,
+            explanation TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY (test_session_id) REFERENCES test_sessions(id)
+        )"""
+    )
+    conn.execute(
+        """INSERT INTO feature_scores
+            (id, test_session_id, feature_name, raw_metric, score,
+             availability_status, failure_reason, explanation, created_at)
+           SELECT id, test_session_id, feature_name, raw_metric, score,
+                  'available', NULL, explanation, created_at
+           FROM feature_scores_legacy"""
+    )
+    conn.execute("DROP TABLE feature_scores_legacy")
+    conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS ux_feature_scores_session_name ON feature_scores(test_session_id, feature_name)")
 
 
 def _repair_legacy_session_number_duplicates(conn: sqlite3.Connection) -> None:
@@ -431,6 +470,7 @@ def create_test_session(
     app_version: str,
     consent_version: str,
     scoring_model_version: str,
+    analysis_pipeline_id: str = "legacy-unknown",
     session_type: str | None = None,
     language: str | None = None,
     duration_seconds: float | None = None,
@@ -443,8 +483,8 @@ def create_test_session(
             INSERT INTO test_sessions
                 (user_id, session_date, session_number, session_type, language,
                  duration_seconds, timezone_name, app_version, consent_version,
-                scoring_model_version, idempotency_key, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                scoring_model_version, analysis_pipeline_id, idempotency_key, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 user_id,
@@ -457,6 +497,7 @@ def create_test_session(
                 app_version,
                 consent_version,
                 scoring_model_version,
+                analysis_pipeline_id,
                 idempotency_key,
                 utc_now_iso(),
             ),
@@ -475,6 +516,7 @@ def complete_test_session(
     app_version: str,
     consent_version: str,
     scoring_model_version: str,
+    analysis_pipeline_id: str = "legacy-unknown",
     scores: Iterable[dict],
     max_tests_per_day: int,
     session_type: str | None = None,
@@ -513,28 +555,31 @@ def complete_test_session(
             INSERT INTO test_sessions
                 (user_id, session_date, session_number, session_type, language,
                  duration_seconds, timezone_name, app_version, consent_version,
-                 scoring_model_version, idempotency_key, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 scoring_model_version, analysis_pipeline_id, idempotency_key, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 user_id, session_date, session_number, session_type, language,
                 duration_seconds, timezone_name, app_version, consent_version,
-                scoring_model_version, idempotency_key, now,
+                scoring_model_version, analysis_pipeline_id, idempotency_key, now,
             ),
         )
         session_id = int(cursor.lastrowid)
         conn.executemany(
             """
             INSERT INTO feature_scores
-                (test_session_id, feature_name, raw_metric, score, explanation, created_at)
-            VALUES (?, ?, ?, ?, ?, ?)
+                (test_session_id, feature_name, raw_metric, score, availability_status,
+                 failure_reason, explanation, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
                 (
                     session_id,
                     item["feature_name"],
                     item.get("raw_metric"),
-                    float(item["score"]),
+                    float(item["score"]) if item.get("score") is not None else None,
+                    item.get("availability_status", "available"),
+                    item.get("failure_reason"),
                     item["explanation"],
                     now,
                 )
@@ -549,15 +594,18 @@ def save_feature_scores(test_session_id: int, scores: Iterable[dict]) -> None:
         conn.executemany(
             """
             INSERT INTO feature_scores
-                (test_session_id, feature_name, raw_metric, score, explanation, created_at)
-            VALUES (?, ?, ?, ?, ?, ?)
+                (test_session_id, feature_name, raw_metric, score, availability_status,
+                 failure_reason, explanation, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
                 (
                     test_session_id,
                     item["feature_name"],
                     item.get("raw_metric"),
-                    float(item["score"]),
+                    float(item["score"]) if item.get("score") is not None else None,
+                    item.get("availability_status", "available"),
+                    item.get("failure_reason"),
                     item["explanation"],
                     utc_now_iso(),
                 )
@@ -582,8 +630,9 @@ def get_user_scores(user_id: int) -> list[sqlite3.Row]:
                 ts.app_version,
                 ts.consent_version,
                 ts.scoring_model_version,
+                ts.analysis_pipeline_id,
                 fs.feature_name,
-                fs.score
+                fs.score, fs.availability_status, fs.failure_reason
             FROM feature_scores fs
             JOIN test_sessions ts ON ts.id = fs.test_session_id
             WHERE ts.user_id = ?

--- a/aoi_kinabot_app/history_view.py
+++ b/aoi_kinabot_app/history_view.py
@@ -9,7 +9,7 @@ import pandas as pd
 from scoring import display_feature_name
 
 
-COMPARISON_KEY_COLUMNS = ("language", "scoring_model_version", "app_version")
+COMPARISON_KEY_COLUMNS = ("language", "scoring_model_version", "analysis_pipeline_id")
 
 
 def comparison_key(row: dict) -> tuple[str, ...]:
@@ -53,6 +53,8 @@ def metric_grid_html(score_items: list[dict], language: str) -> str:
     """Return a compact two-column score grid suitable for narrow screens."""
     tiles = []
     for item in score_items:
+        if item.get("score") is None:
+            continue
         score = int(round(float(item["score"])))
         label = escape(display_feature_name(str(item["feature_name"]), language))
         tiles.append(

--- a/aoi_kinabot_app/insight_service.py
+++ b/aoi_kinabot_app/insight_service.py
@@ -88,6 +88,8 @@ def anonymous_trend_payload(history: list[dict[str, Any]], language: str) -> dic
     """Build the complete and exclusive payload allowed to leave KinaBot."""
     feature_series: dict[str, list[float]] = {}
     for row in history:
+        if row.get("score") is None or row.get("availability_status") == "unavailable":
+            continue
         name = str(row["feature_name"])
         feature_series.setdefault(name, []).append(round(float(row["score"]), 1))
     return {

--- a/aoi_kinabot_app/reflection_profile.py
+++ b/aoi_kinabot_app/reflection_profile.py
@@ -78,16 +78,23 @@ COPY = {
 
 def build_reflection_profile(scores: list[dict[str, Any]], language: str) -> dict:
     """Aggregate existing local features into four transparent UX dimensions."""
-    values = {str(item["feature_name"]): float(item["score"]) for item in scores}
+    values = {
+        str(item["feature_name"]): float(item["score"])
+        for item in scores
+        if item.get("score") is not None
+    }
     dimensions = {
-        name: round(
-            sum(values.get(feature, 0.0) for feature in features) / len(features)
+        name: (
+            round(sum(values[feature] for feature in features if feature in values)
+                  / sum(feature in values for feature in features))
+            if any(feature in values for feature in features) else None
         )
         for name, features in PROFILE_COMPONENTS.items()
     }
     copy = COPY.get(language, COPY["English"])
-    strongest = max(dimensions, key=dimensions.get)
-    focus = min(dimensions, key=dimensions.get)
+    available_dimensions = {key: value for key, value in dimensions.items() if value is not None}
+    strongest = max(available_dimensions, key=available_dimensions.get) if available_dimensions else None
+    focus = min(available_dimensions, key=available_dimensions.get) if available_dimensions else None
     labels = copy["labels"]
     return {
         "title": copy["title"],
@@ -97,11 +104,11 @@ def build_reflection_profile(scores: list[dict[str, Any]], language: str) -> dic
             for key in PROFILE_COMPONENTS
         ],
         "takeaway_title": copy["takeaway"],
-        "takeaway": copy["summary"].format(
-            strong=labels[strongest],
-            focus=labels[focus],
+        "takeaway": (
+            copy["summary"].format(strong=labels[strongest], focus=labels[focus])
+            if strongest else "No comparable measured features are available for this recording."
         ),
         "action_title": copy["action_title"],
-        "action": copy["actions"][focus],
+        "action": copy["actions"][focus] if focus else "Try a clearer recording with duration and audio analysis available.",
         "detail_label": copy["detail"],
     }

--- a/aoi_kinabot_app/scoring.py
+++ b/aoi_kinabot_app/scoring.py
@@ -211,18 +211,18 @@ def score_sentence_complexity(
 
 def score_speech_pace(
     words: list[str], duration_seconds: float | None, language: str
-) -> tuple[float, str]:
+) -> tuple[float | None, str, str | None]:
     if not duration_seconds or duration_seconds <= 0:
-        return 50.0, "duration_seconds=unknown; neutral_score_used=true"
+        return None, "duration_seconds=unknown", "duration_unknown"
     units_per_minute = len(words) / duration_seconds * 60
     center = {"en": 130, "ja": 110, "zh": 110}[language_code(language)]
     score = 100 - abs(units_per_minute - center) * 0.5
-    return clamp_score(score), f"units_per_minute={units_per_minute:.2f}; center={center}"
+    return clamp_score(score), f"units_per_minute={units_per_minute:.2f}; center={center}", None
 
 
-def score_pause_pattern(acoustic_metrics: dict | None) -> tuple[float, str]:
+def score_pause_pattern(acoustic_metrics: dict | None) -> tuple[float | None, str, str | None]:
     if not acoustic_metrics:
-        return 50.0, "pause_analysis=unavailable; neutral_score_used=true"
+        return None, "pause_analysis=unavailable", "acoustic_analysis_unavailable"
     pause_ratio = float(acoustic_metrics.get("pause_ratio", 0.0))
     mean_pause = float(acoustic_metrics.get("mean_pause_seconds", 0.0))
     # A broad descriptive center avoids treating one exact speaking style as ideal.
@@ -246,7 +246,7 @@ def score_pause_pattern(acoustic_metrics: dict | None) -> tuple[float, str]:
             "pause_ratio",
         }
     )
-    return clamp_score(score), raw
+    return clamp_score(score), raw, None
 
 
 def score_repetition_pattern(words: list[str]) -> tuple[float, str]:
@@ -305,11 +305,18 @@ def calculate_feature_scores(
     ]
     results = []
     for feature_name, builder in score_builders:
-        score, raw_metric = builder()
+        built = builder()
+        if len(built) == 2:
+            score, raw_metric = built
+            failure_reason = None
+        else:
+            score, raw_metric, failure_reason = built
         results.append(
             {
                 "feature_name": feature_name,
                 "score": score,
+                "availability_status": "unavailable" if score is None else "available",
+                "failure_reason": failure_reason,
                 "raw_metric": raw_metric,
                 "explanation": feature_explanation(feature_name, language),
                 "scoring_model_version": SCORING_MODEL_VERSION,

--- a/aoi_kinabot_app/test_measurement_integrity.py
+++ b/aoi_kinabot_app/test_measurement_integrity.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from history_view import select_latest_comparable_history
+from scoring import calculate_feature_scores
+
+
+def test_unavailable_audio_features_are_explicit_not_neutral_scores():
+    scores = calculate_feature_scores("A short sample.", duration_seconds=None)
+    by_name = {item["feature_name"]: item for item in scores}
+    assert by_name["Speech Pace"]["score"] is None
+    assert by_name["Speech Pace"]["availability_status"] == "unavailable"
+    assert by_name["Speech Pace"]["failure_reason"] == "duration_unknown"
+    assert by_name["Pause Pattern"]["score"] is None
+
+
+def test_trends_require_pipeline_provenance():
+    history = pd.DataFrame([
+        {"session_id": 1, "language": "English", "scoring_model_version": "s", "analysis_pipeline_id": "p1"},
+        {"session_id": 2, "language": "English", "scoring_model_version": "s", "analysis_pipeline_id": "p1"},
+        {"session_id": 3, "language": "English", "scoring_model_version": "s", "analysis_pipeline_id": "p2"},
+    ])
+    comparable, key = select_latest_comparable_history(history, minimum_sessions=2)
+    assert key == ("English", "s", "p1")
+    assert set(comparable["session_id"]) == {1, 2}

--- a/aoi_kinabot_app/test_multilingual.py
+++ b/aoi_kinabot_app/test_multilingual.py
@@ -32,7 +32,10 @@ def test_local_nlp_scores_multilingual():
     ]:
         scores, summary = analyze_transcript(text, language, 30)
         assert len(scores) == 8
-        assert all(0 <= item["score"] <= 100 for item in scores)
+        assert all(
+            item["score"] is None or 0 <= item["score"] <= 100
+            for item in scores
+        )
         assert summary
 
 


### PR DESCRIPTION
## Summary\n- Store unavailable feature measurements as null with a stable status and reason instead of a neutral 50\n- Exclude unavailable values from participant summaries, trends, and anonymous wellness payloads\n- Record analysis_pipeline_id on sessions and include it in trend compatibility\n- Preserve legacy records as legacy-unknown and migrate existing SQLite score tables safely\n- Add regression tests for unavailable measurements and pipeline-isolated trends\n\n## Validation\n- 26 targeted tests passed\n- Python syntax compilation passed\n- Full app test collection is blocked locally only because FastAPI is not installed in the current environment; it is listed in requirements-offline.txt.