### PR TITLE
Preserve legacy trend compatibility for pipeline provenance

### DIFF
--- a/aoi_kinabot_app/history_view.py
+++ b/aoi_kinabot_app/history_view.py
@@ -14,7 +14,12 @@ COMPARISON_KEY_COLUMNS = ("language", "scoring_model_version", "analysis_pipelin
 
 def comparison_key(row: dict) -> tuple[str, ...]:
     """Return the provenance key that makes two sessions comparable."""
-    return tuple(str(row.get(column) or "unknown") for column in COMPARISON_KEY_COLUMNS)
+    # Legacy sessions predate analysis_pipeline_id; app_version is the safest
+    # compatibility discriminator available for those records.
+    pipeline_id = row.get("analysis_pipeline_id") or row.get("app_version") or "unknown"
+    return (str(row.get("language") or "unknown"),
+            str(row.get("scoring_model_version") or "unknown"),
+            str(pipeline_id))
 
 
 def select_latest_comparable_history(


### PR DESCRIPTION
Follow-up to Issue #54 and PR #60.\n\nLegacy sessions do not have analysis_pipeline_id. Trend comparison now prefers the pipeline ID for new sessions and falls back to app_version for legacy records, preserving existing behavior without treating new sessions as legacy.\n\nValidation: existing history comparability and measurement-integrity tests pass locally.