### PR TITLE
docs: add Zenodo DOI for v1.1.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,10 +2,13 @@ cff-version: 1.2.0
 message: "If you use KinaBot in research, education, or evaluation, please cite this software and the exact release used."
 title: "KinaBot"
 type: software
+version: "v1.1.0"
+date-released: "2026-09-04"
 authors:
   - family-names: "Minamoto"
     given-names: "Aoi"
 repository-code: "https://github.com/usekina/kina"
+doi: "10.5281/zenodo.22305528"
 url: "https://www.kinabot.com/"
 abstract: "A dignity-first, privacy-aware system for longitudinal speech reflection, healthy aging, and family-centered care."
 keywords:

--- a/aoi_kinabot_app/history_view.py
+++ b/aoi_kinabot_app/history_view.py
@@ -14,7 +14,12 @@ COMPARISON_KEY_COLUMNS = ("language", "scoring_model_version", "analysis_pipelin
 
 def comparison_key(row: dict) -> tuple[str, ...]:
     """Return the provenance key that makes two sessions comparable."""
-    return tuple(str(row.get(column) or "unknown") for column in COMPARISON_KEY_COLUMNS)
+    # Legacy sessions predate analysis_pipeline_id; app_version is the safest
+    # compatibility discriminator available for those records.
+    pipeline_id = row.get("analysis_pipeline_id") or row.get("app_version") or "unknown"
+    return (str(row.get("language") or "unknown"),
+            str(row.get("scoring_model_version") or "unknown"),
+            str(pipeline_id))
 
 
 def select_latest_comparable_history(


### PR DESCRIPTION
Adds the published Zenodo DOI and release metadata to CITATION.cff for reproducible citation of KinaBot v1.1.0.